### PR TITLE
Enable disk encryption for workstation teams

### DIFF
--- a/teams/workstations-canary.yml
+++ b/teams/workstations-canary.yml
@@ -27,5 +27,8 @@ team_settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
+  mdm:
+    macos_settings:
+      enable_disk_encryption: true
 software:
 

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -27,4 +27,7 @@ team_settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
+  mdm:
+    macos_settings:
+      enable_disk_encryption: true
 software:


### PR DESCRIPTION
## Summary
- enable macOS disk encryption for Workstations team
- enable macOS disk encryption for Workstations (canary) team

## Testing
- `GOOGLE_SSO_METADATA='' FLEET_DRY_RUN_ONLY=true ./gitops.sh` *(fails: fleetctl: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce69a4f108321a8798043d41edd46