### PR TITLE
Add platform labels for macOS, iOS, and Linux

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -14,6 +14,30 @@ agent_options:
       pack_delimiter: /
   overrides:
 labels:
+  - name: macOS
+    description: All macOS hosts
+    query: SELECT 1 FROM system_info WHERE platform = 'darwin';
+    label_membership_type: dynamic
+  - name: macOS 14+ (Sonoma+)
+    description: Hosts running macOS 14 or later
+    query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major >= 14;
+    label_membership_type: dynamic
+  - name: iOS
+    description: All iOS hosts
+    query: SELECT 1 FROM system_info WHERE platform = 'ios';
+    label_membership_type: dynamic
+  - name: Linux
+    description: All Linux hosts
+    query: SELECT 1 FROM system_info WHERE platform = 'linux';
+    label_membership_type: dynamic
+  - name: Ubuntu Linux
+    description: All Ubuntu Linux hosts
+    query: SELECT 1 FROM os_version WHERE platform = 'ubuntu';
+    label_membership_type: dynamic
+  - name: All Hosts
+    description: All hosts
+    query: SELECT 1 FROM osquery_info;
+    label_membership_type: dynamic
 org_settings:
   features:
     enable_host_users: true


### PR DESCRIPTION
## Summary
- add macOS label for hosts running on Darwin
- add macOS 14+ (Sonoma+) label
- add iOS label
- add Linux label
- add Ubuntu Linux label
- add All Hosts label

## Testing
- `GOOGLE_SSO_METADATA='' GLOBAL_ENROLL_SECRET='dummy' FLEET_URL='https://example.com' FLEET_API_TOKEN='fake' FLEET_DRY_RUN_ONLY=true ./gitops.sh` *(fails: fleetctl: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7a7de50832181a9bda024f82404