### PR TITLE
Github Desktop 3.5.2

### DIFF
--- a/lib/macos/software/github-desktop.yml
+++ b/lib/macos/software/github-desktop.yml
@@ -1,5 +1,5 @@
 name: Github Desktop
 version: 3.5.2
 platform: darwin
-hash_sha256: 4d9bee7806d5d3c87dbef20d2f2b3beaa41e67e26aba11df1c07c1b83f90b31f
+hash_sha256: 768b6b2f19a9bb6509335a3b39d541d3ba8918c128bb43acec223ed2bd6dea92
 self_service: true


### PR DESCRIPTION
### Github Desktop 3.5.2

- Fleet title ID: `None`
- Fleet installer ID: `None`
- Software slug: `github-desktop`