### PR TITLE
Github Desktop 3.5.2

### DIFF
--- a/lib/macos/software/github-desktop.yml
+++ b/lib/macos/software/github-desktop.yml
@@ -1,5 +1,5 @@
 name: Github Desktop
 version: 3.5.2
 platform: darwin
-hash_sha256: 4d9bee7806d5d3c87dbef20d2f2b3beaa41e67e26aba11df1c07c1b83f90b31f
+hash_sha256: 6c402dfc6e1444111c4018fbc5b54f675211ed9737f9f5db89d354a49b5d9d2b
 self_service: true


### PR DESCRIPTION
### Github Desktop 3.5.2

- Fleet title ID: `None`
- Fleet installer ID: `None`
- Software slug: `github-desktop`