### PR TITLE
Google Chrome 140.0.7339.133

### DIFF
--- a/lib/macos/software/google-chrome.yml
+++ b/lib/macos/software/google-chrome.yml
@@ -1,7 +1,5 @@
-url: https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
+name: Google Chrome
+version: 140.0.7339.133
+platform: darwin
+hash_sha256: 704435fa4099a0358da51bae1bd9b4976d6b04dc78bd888a3504dce800bce04d
 self_service: true
-post_install_script:
-  path: ../scripts/google-chrome-post-install.sh
-categories:
-  - Browsers
-  


### PR DESCRIPTION
### Google Chrome 140.0.7339.133

- Fleet title ID: `None`
- Fleet installer ID: `None`
- Software slug: `google-chrome`