### PR TITLE
Github Desktop 3.5.2

### DIFF
--- a/lib/macos/software/github-desktop.yml
+++ b/lib/macos/software/github-desktop.yml
@@ -1,5 +1,5 @@
 name: Github Desktop
 version: 3.5.2
 platform: darwin
-hash_sha256: 4d9bee7806d5d3c87dbef20d2f2b3beaa41e67e26aba11df1c07c1b83f90b31f
+hash_sha256: fe48e4229a20a2a5bbf5cc993633c176088a164e2dd451baab870717aae10997
 self_service: true


### PR DESCRIPTION
### Github Desktop 3.5.2

- Fleet title ID: `None`
- Fleet installer ID: `None`
- Software slug: `github-desktop`