### PR TITLE
Google Chrome 140.0.7339.133

### DIFF
--- a/lib/macos/software/google-chrome.yml
+++ b/lib/macos/software/google-chrome.yml
@@ -1,7 +1,5 @@
-url: https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
+name: Google Chrome
+version: 140.0.7339.133
+platform: darwin
+hash_sha256: a28e66424c0aefc6e35ed496e6846b579fed00a8e30cb9ae815395c9f75e2bb5
 self_service: true
-post_install_script:
-  path: ../scripts/google-chrome-post-install.sh
-categories:
-  - Browsers
-  


### PR DESCRIPTION
### Google Chrome 140.0.7339.133

- Fleet title ID: `None`
- Fleet installer ID: `None`
- Software slug: `google-chrome`