### PR TITLE
Update OS update deadlines and minimum versions

### DIFF
--- a/teams/mobile-devices.yml
+++ b/teams/mobile-devices.yml
@@ -15,11 +15,11 @@ agent_options:
 controls:
   enable_disk_encryption: true
   ios_updates:
-    deadline: "2025-09-10"
-    minimum_version: "18.6.2"
+    deadline: "2025-09-17"
+    minimum_version: "18.7"
   ipados_updates:
-    deadline: "2025-09-10"
-    minimum_version: "18.6.2"
+    deadline: "2025-09-17"
+    minimum_version: "18.7"
   macos_settings:
     custom_settings:
   scripts:

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -12,14 +12,8 @@ agent_options:
 controls:
   enable_disk_encryption: true
   macos_updates:
-    deadline: '2025-09-10'
-    minimum_version: 15.6.1
-  ios_updates:
-    deadline: '2025-09-10'
-    minimum_version: 18.6.2
-  ipados_updates:
-    deadline: '2025-09-10'
-    minimum_version: 18.6.2
+    deadline: '2025-09-17'
+    minimum_version: '15.7'
   macos_settings:
     custom_settings:
     - path: ../lib/macos/configuration-profiles/macos-password.mobileconfig


### PR DESCRIPTION
Updated iOS, iPadOS, and macOS update deadlines to 2025-09-17 and raised minimum required versions in both mobile-devices and workstations team configs.