### PR TITLE
Caffeine 1.5.3

### DIFF
--- a/lib/macos/software/caffeine.yml
+++ b/lib/macos/software/caffeine.yml
@@ -1,0 +1,5 @@
+name: Caffeine
+version: 1.5.3
+platform: darwin
+hash_sha256: 4d794086e064c7b256022d9b488b95018e991f348856248a3adb07d07d7e1b04
+self_service: true

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -41,3 +41,4 @@ software:
   - path: ../lib/macos/software/zoom.yml
   - path: ../lib/macos/software/1password.yml
   - path: ../lib/macos/software/github-desktop.yml
+  - path: ../lib/macos/software/caffeine.yml


### PR DESCRIPTION
### Caffeine 1.5.3

- Fleet title ID: `1813`
- Fleet installer ID: `105`
- Software slug: `caffeine`