### PR TITLE
Signal 7.71.0

### DIFF
--- a/lib/macos/software/signal.yml
+++ b/lib/macos/software/signal.yml
@@ -1,0 +1,5 @@
+name: Signal
+version: 7.71.0
+platform: darwin
+hash_sha256: a91476089e9496581b5c2a729816c6e33f1a5d70868161294222b87e47b587eb
+self_service: true

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -44,3 +44,4 @@ software:
   - path: ../lib/macos/software/caffeine.yml
   - path: ../lib/macos/software/gpg-suite.yml
     self_service: true
+  - path: ../lib/macos/software/signal.yml


### PR DESCRIPTION
### Signal 7.71.0

- Fleet title ID: `925`
- Fleet installer ID: `145`
- Software slug: `signal`