### PR TITLE
Increase max inactivity duration in password policy

### DIFF
--- a/lib/macos/configuration-profiles/macos-password.mobileconfig
+++ b/lib/macos/configuration-profiles/macos-password.mobileconfig
@@ -28,7 +28,7 @@
 			<key>maxGracePeriod</key>
 			<integer>1</integer>
 			<key>maxInactivity</key>
-			<integer>15</integer>
+			<integer>20</integer>
 			<key>minLength</key>
 			<integer>8</integer>
 			<key>requireAlphanumeric</key>


### PR DESCRIPTION
Update the maximum inactivity duration from 15 minutes to 20 minutes in the password policy.