### PR TITLE
Zoom 6.6.2.65462

### DIFF
--- a/lib/macos/software/zoom.yml
+++ b/lib/macos/software/zoom.yml
@@ -1,0 +1,5 @@
+name: Zoom
+version: 6.6.2.65462
+platform: darwin
+hash_sha256: 5ccb411a0c8138449d204d580b5ff30c6371e4e2cd05878bd26098021db625ff
+self_service: true

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -41,3 +41,4 @@ software:
   - path: ../lib/macos/software/caffeine.yml
   - path: ../lib/macos/software/gpg-suite.yml
   - path: ../lib/macos/software/signal.yml
+  - path: ../lib/macos/software/zoom.yml


### PR DESCRIPTION
### Zoom 6.6.2.65462

- Fleet title ID: `911`
- Fleet installer ID: `298`
- Software slug: `zoom`