### PR TITLE
Google Chrome 141.0.7390.55

### DIFF
--- a/lib/macos/software/google-chrome.yml
+++ b/lib/macos/software/google-chrome.yml
@@ -1,0 +1,5 @@
+name: Google Chrome
+version: 141.0.7390.55
+platform: darwin
+hash_sha256: 3e553a152fc088c990992b6218c690c331d5950318276baefcdbe7ef8ac1d470
+self_service: true

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -41,3 +41,4 @@ software:
   - path: ../lib/macos/software/caffeine.yml
   - path: ../lib/macos/software/gpg-suite.yml
   - path: ../lib/macos/software/signal.yml
+  - path: ../lib/macos/software/google-chrome.yml


### PR DESCRIPTION
### Google Chrome 141.0.7390.55

- Fleet title ID: `976`
- Fleet installer ID: `332`
- Software slug: `google-chrome`