### PR TITLE
Zoom 6.6.2.65462

### DIFF
--- a/lib/macos/software/zoom.yml
+++ b/lib/macos/software/zoom.yml
@@ -1,0 +1,5 @@
+name: Zoom
+version: 6.6.2.65462
+platform: darwin
+hash_sha256: 2e105b19a986710ea9097a1fac649e99444060ea12d3b8c673e7824b0de5bafb
+self_service: true

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -41,3 +41,4 @@ software:
   - path: ../lib/macos/software/caffeine.yml
   - path: ../lib/macos/software/gpg-suite.yml
   - path: ../lib/macos/software/signal.yml
+  - path: ../lib/macos/software/zoom.yml


### PR DESCRIPTION
### Zoom 6.6.2.65462

- Fleet title ID: `911`
- Fleet installer ID: `334`
- Software slug: `zoom`