### PR TITLE
Update OS versions to 26.4.1 and remove guest account policy

### DIFF
--- a/lib/macos/policies/macos-device-health.policies.yml
+++ b/lib/macos/policies/macos-device-health.policies.yml
@@ -4,12 +4,6 @@
   resolution: As an IT admin, turn on disk encryption in Fleet.
   query: SELECT 1 FROM filevault_status WHERE status = 'FileVault is On.';
 
-- name: macOS - Disable guest account
-  platform: darwin
-  description: This policy checks if the guest account is disabled.
-  resolution: An an IT admin, deploy a macOS, login window profile with the DisableGuestAccount option set to true.
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.loginwindow' AND username = '' AND name='DisableGuestAccount' AND CAST(value AS INT) = 1;
-
 - name: macOS - Enable Firewall
   platform: darwin
   description: This policy checks if Firewall is enabled.

--- a/teams/mobile-devices.yml
+++ b/teams/mobile-devices.yml
@@ -15,11 +15,11 @@ agent_options:
 controls:
   enable_disk_encryption: true
   ios_updates:
-    deadline: "2026-04-01"
-    minimum_version: "26.4"
+    deadline: "2026-04-16"
+    minimum_version: "26.4.1"
   ipados_updates:
-    deadline: "2026-04-01"
-    minimum_version: "26.4"
+    deadline: "2026-04-16"
+    minimum_version: "26.4.1"
   macos_settings:
     custom_settings:
   scripts:

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -11,8 +11,8 @@ agent_options:
 controls:
   enable_disk_encryption: true
   macos_updates:
-    deadline: '2026-04-01'
-    minimum_version: '26.4'
+    deadline: '2026-04-16'
+    minimum_version: '26.4.1'
   macos_settings:
     custom_settings:
     - path: ../lib/macos/configuration-profiles/macos-password.mobileconfig


### PR DESCRIPTION
This PR includes the following changes:

- Bumps macOS, iOS, and iPadOS minimum versions from 26.4 to 26.4.1
- Updates deadlines from 2026-04-01 to 2026-04-16 (one week from today)
- Removes the macOS guest account disabled policy check from device health policies

Files changed:
- `teams/workstations.yml`: Updated macOS version and deadline
- `teams/mobile-devices.yml`: Updated iOS and iPadOS versions and deadlines
- `lib/macos/policies/macos-device-health.policies.yml`: Removed guest account disabled policy