### PR TITLE
Add fleet maintained apps

### DIFF
--- a/lib/macos/policies/macos-fma-patch.policies.yml
+++ b/lib/macos/policies/macos-fma-patch.policies.yml
@@ -2,21 +2,53 @@
   type: patch
   fleet_maintained_app_slug: 1password/darwin
   install_software: true
+- name: Canva up to date
+  type: patch
+  fleet_maintained_app_slug: canva/darwin
+  install_software: true
 - name: Claude up to date
   type: patch
   fleet_maintained_app_slug: claude/darwin
+  install_software: true
+- name: Discord up to date
+  type: patch
+  fleet_maintained_app_slug: discord/darwin
   install_software: true
 - name: Docker Desktop up to date
   type: patch
   fleet_maintained_app_slug: docker-desktop/darwin
   install_software: true
+- name: Elgato Control Center up to date
+  type: patch
+  fleet_maintained_app_slug: elgato-control-center/darwin
+  install_software: true
+- name: Elgato Stream Deck up to date
+  type: patch
+  fleet_maintained_app_slug: elgato-stream-deck/darwin
+  install_software: true
+- name: GitHub Desktop up to date
+  type: patch
+  fleet_maintained_app_slug: github/darwin
+  install_software: true
 - name: Google Chrome up to date
   type: patch
   fleet_maintained_app_slug: google-chrome/darwin
   install_software: true
+- name: Google Drive up to date
+  type: patch
+  fleet_maintained_app_slug: google-drive/darwin
+  install_software: true
+- name: iMazing Profile Editor up to date
+  type: patch
+  fleet_maintained_app_slug: imazing-profile-editor/darwin
+  install_software: true
 - name: iTerm2 up to date
   type: patch
   fleet_maintained_app_slug: iterm2/darwin
+  install_software: true
+- name: Logi Options+ up to date
+  type: patch
+  fleet_maintained_app_slug: logi-options+/darwin
   install_software: true
 - name: Visual Studio Code up to date
   type: patch
@@ -30,9 +62,33 @@
   type: patch
   fleet_maintained_app_slug: postman/darwin
   install_software: true
+- name: Raycast up to date
+  type: patch
+  fleet_maintained_app_slug: raycast/darwin
+  install_software: true
+- name: Signal up to date
+  type: patch
+  fleet_maintained_app_slug: signal/darwin
+  install_software: true
 - name: Slack up to date
   type: patch
   fleet_maintained_app_slug: slack/darwin
+  install_software: true
+- name: Suspicious Package up to date
+  type: patch
+  fleet_maintained_app_slug: suspicious-package/darwin
+  install_software: true
+- name: Tailscale up to date
+  type: patch
+  fleet_maintained_app_slug: tailscale-app/darwin
+  install_software: true
+- name: UTM up to date
+  type: patch
+  fleet_maintained_app_slug: utm/darwin
+  install_software: true
+- name: VLC up to date
+  type: patch
+  fleet_maintained_app_slug: vlc/darwin
   install_software: true
 - name: WhatsApp up to date
   type: patch

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -46,16 +46,40 @@ software:
   - slug: 1password/darwin
     setup_experience: false
     self_service: true
+  - slug: canva/darwin
+    setup_experience: false
+    self_service: true
   - slug: claude/darwin
+    setup_experience: false
+    self_service: true
+  - slug: discord/darwin
     setup_experience: false
     self_service: true
   - slug: docker-desktop/darwin
     setup_experience: false
     self_service: true
+  - slug: elgato-control-center/darwin
+    setup_experience: false
+    self_service: true
+  - slug: elgato-stream-deck/darwin
+    setup_experience: false
+    self_service: true
+  - slug: github/darwin
+    setup_experience: false
+    self_service: true
   - slug: google-chrome/darwin
     setup_experience: false
     self_service: true
+  - slug: google-drive/darwin
+    setup_experience: false
+    self_service: true
+  - slug: imazing-profile-editor/darwin
+    setup_experience: false
+    self_service: true
   - slug: iterm2/darwin
+    setup_experience: false
+    self_service: true
+  - slug: logi-options+/darwin
     setup_experience: false
     self_service: true
   - slug: visual-studio-code/darwin
@@ -67,7 +91,25 @@ software:
   - slug: postman/darwin
     setup_experience: false
     self_service: true
+  - slug: raycast/darwin
+    setup_experience: false
+    self_service: true
+  - slug: signal/darwin
+    setup_experience: false
+    self_service: true
   - slug: slack/darwin
+    setup_experience: false
+    self_service: true
+  - slug: suspicious-package/darwin
+    setup_experience: false
+    self_service: true
+  - slug: tailscale-app/darwin
+    setup_experience: false
+    self_service: true
+  - slug: utm/darwin
+    setup_experience: false
+    self_service: true
+  - slug: vlc/darwin
     setup_experience: false
     self_service: true
   - slug: whatsapp/darwin


### PR DESCRIPTION
- Canva
- Discord
- Elgato Control Center
- Elgato Stream Deck
- GitHub Desktop
- Google Drive
- iMazing Profile Editor
- Logi Options+
- Raycast
- Signal
- Suspicious Package
- Tailscale
- UTM
- VLC