### PR TITLE
Bump OS update minimums and deadline to 2026-05-04

### DIFF
--- a/fleets/mobile-devices.yml
+++ b/fleets/mobile-devices.yml
@@ -15,11 +15,11 @@ agent_options:
 controls:
   enable_disk_encryption: true
   ios_updates:
-    deadline: "2026-04-16"
-    minimum_version: "26.4.1"
+    deadline: "2026-05-04"
+    minimum_version: "26.4.2"
   ipados_updates:
-    deadline: "2026-04-16"
-    minimum_version: "26.4.1"
+    deadline: "2026-05-04"
+    minimum_version: "26.4.2"
   apple_settings:
     configuration_profiles:
   scripts:

--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -12,7 +12,7 @@ agent_options:
 controls:
   enable_disk_encryption: true
   macos_updates:
-    deadline: '2026-04-16'
+    deadline: '2026-05-04'
     minimum_version: '26.4.1'
   apple_settings:
     configuration_profiles:


### PR DESCRIPTION
## Summary
- macOS pinned to 26.4.1 (latest; Apple has not released a 26.4.2 for macOS)
- iOS and iPadOS bumped to 26.4.2 (released April 22, 2026)
- Deadline moved from 2026-04-16 to Monday 2026-05-04

## Test plan
- [ ] Confirm GitOps run applies cleanly
- [ ] Verify macOS workstations enforce 26.4.1 by 2026-05-04
- [ ] Verify iOS/iPadOS devices enforce 26.4.2 by 2026-05-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)