### PR TITLE
Disable macOS Content Caching on workstations

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -37,6 +37,9 @@ controls:
     - path: ../lib/macos/configuration-profiles/fleetd-full-disk-access.mobileconfig
       labels_include_any:
       - macOS hosts
+    - path: ../lib/macos/configuration-profiles/disable-content-caching.mobileconfig
+      labels_include_any:
+      - macOS hosts
   scripts: null
 settings:
   secrets:

--- a/lib/macos/configuration-profiles/disable-content-caching.mobileconfig
+++ b/lib/macos/configuration-profiles/disable-content-caching.mobileconfig
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadDescription</key>
+            <string>Disables Content Caching on macOS</string>
+            <key>PayloadDisplayName</key>
+            <string>Restrictions: Disable Content Caching</string>
+            <key>PayloadIdentifier</key>
+            <string>com.kitzy.disablecontentcaching.9D151E93</string>
+            <key>PayloadOrganization</key>
+            <string>Testing</string>
+            <key>PayloadType</key>
+            <string>com.apple.applicationaccess</string>
+            <key>PayloadUUID</key>
+            <string>9D151E93-E856-47DB-8F03-80E3128F5675</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>allowContentCaching</key>
+            <false/>
+        </dict>
+    </array>
+    <key>PayloadDescription</key>
+    <string>Disables the macOS Content Caching service.</string>
+    <key>PayloadDisplayName</key>
+    <string>Disable Content Caching</string>
+    <key>PayloadIdentifier</key>
+    <string>com.kitzy.profile.disablecontentcaching</string>
+    <key>PayloadOrganization</key>
+    <string>Testing</string>
+    <key>PayloadScope</key>
+    <string>System</string>
+    <key>PayloadType</key>
+    <string>Configuration</string>
+    <key>PayloadUUID</key>
+    <string>DBCEE8F5-65A3-4B9D-93BE-AD8F88F171AB</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `lib/macos/configuration-profiles/disable-content-caching.mobileconfig`, a profile that sets `allowContentCaching=false` via the `com.apple.applicationaccess` payload.
- Applies the profile to macOS hosts in the Workstations fleet.

## Notes
- `allowContentCaching` is documented as a supervised-only restriction, so it enforces only on supervised Macs (anything enrolled via ADE/DEP). User-enrolled Macs would need a different mechanism (e.g., `AssetCacheManagerUtil deactivate` via a script).

## Test plan
- [x] GitOps run applies cleanly with no schema errors.
- [x] Profile shows installed on a supervised macOS host.
- [x] System Settings > General > Sharing > Content Caching is disabled / not toggleable on that host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)