### PR TITLE
Bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Load secrets from 1Password
         id: op-secrets
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@v4
         with:
           export-env: false
         env:
@@ -45,7 +45,7 @@ jobs:
           FLEET_VULNERABILITY_WEBHOOK_URL: op://GitHub/FleetSecrets/FLEET_VULNERABILITY_WEBHOOK_URL
           
       - name: Checkout GitOps repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Apply latest configuration to Fleet
         uses: ./.github/gitops-action


### PR DESCRIPTION
## Summary
- Bump `1password/load-secrets-action@v2` → `@v4` (now runs on Node 24)
- Bump `actions/checkout@v4` → `@v6` (now runs on Node 24)

Addresses the GitHub Actions deprecation warning for Node.js 20. Node 20 will be removed from runners on 2026-09-16.

The workflow already sets `export-env: false` explicitly, so the v3 default-flip breaking change in `1password/load-secrets-action` does not affect it.

## Test plan
- [x] CI runs cleanly on this PR (the `Apply latest configuration to Fleet` workflow runs on `pull_request`, exercising both bumped actions in dry-run mode)
- [x] No more Node.js 20 deprecation warning in the run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)