### PR TITLE
Remove Firefox from workstations

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -76,9 +76,6 @@ software:
   - slug: elgato-stream-deck/darwin
     setup_experience: false
     self_service: true
-  - slug: firefox/darwin
-    setup_experience: false
-    self_service: true
   - slug: ghostty/darwin
     setup_experience: false
     self_service: true


### PR DESCRIPTION
## Summary
- Removes the `firefox/darwin` fleet-maintained app entry from [fleets/workstations.yml](fleets/workstations.yml), reverting the addition from #146.

## Test plan
- [ ] Confirm Fleet GitOps run succeeds and Firefox is removed from the Workstations team's self-service catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)