### PR TITLE
Add enable-touch-id-sudo self-service script for workstations

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -48,6 +48,12 @@ settings:
     enable_host_users: true
     enable_software_inventory: true
 software:
+  packages:
+  - path: ../lib/macos/scripts/enable-touch-id-sudo.sh
+    display_name: Enable Touch ID for sudo
+    self_service: true
+    categories:
+    - Developer tools
   fleet_maintained_apps:
   - slug: 1password/darwin
     setup_experience: false

--- a/lib/macos/scripts/enable-touch-id-sudo.sh
+++ b/lib/macos/scripts/enable-touch-id-sudo.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Enables Touch ID authentication for sudo on macOS 15+.
+
+set -euo pipefail
+
+if test "$(id -u)" -ne 0; then
+  echo "[enable-touch-id-sudo] This script must run as root. Fleet scripts run as root by default."
+  exit 1
+fi
+
+if test ! -f /etc/pam.d/sudo_local.template; then
+  echo "[enable-touch-id-sudo] Expected /etc/pam.d/sudo_local.template on macOS 15+, but it was not found."
+  exit 1
+fi
+
+if test ! -f /etc/pam.d/sudo_local; then
+  echo "[enable-touch-id-sudo] Creating /etc/pam.d/sudo_local from template."
+  cp /etc/pam.d/sudo_local.template /etc/pam.d/sudo_local
+fi
+
+if grep -Eq '^[[:space:]]*auth[[:space:]]+sufficient[[:space:]]+pam_tid\.so' /etc/pam.d/sudo_local; then
+  echo "[enable-touch-id-sudo] Touch ID for sudo is already enabled in /etc/pam.d/sudo_local."
+  exit 0
+fi
+
+if grep -Eq '^[[:space:]]*#[[:space:]]*auth[[:space:]]+sufficient[[:space:]]+pam_tid\.so' /etc/pam.d/sudo_local; then
+  echo "[enable-touch-id-sudo] Uncommenting pam_tid line in /etc/pam.d/sudo_local."
+  sed -i "" -E 's/^[[:space:]]*#[[:space:]]*(auth[[:space:]]+sufficient[[:space:]]+pam_tid\.so)/\1/' /etc/pam.d/sudo_local
+else
+  echo "[enable-touch-id-sudo] Appending pam_tid line to /etc/pam.d/sudo_local."
+  printf '%s\n' 'auth       sufficient     pam_tid.so' >> /etc/pam.d/sudo_local
+fi
+
+echo "[enable-touch-id-sudo] Touch ID for sudo enabled via /etc/pam.d/sudo_local."


### PR DESCRIPTION
## Summary
- Adds the upstream Fleet [enable-touch-id-sudo.sh](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/macos/scripts/enable-touch-id-sudo.sh) as a self-service item on the Workstations team so end users can opt in to Touch ID for sudo from Fleet Desktop.
- Registered as a script-only `software.packages` entry with `self_service: true`, category `Developer tools`, and `display_name: Enable Touch ID for sudo`.
- Script is idempotent (no-ops if pam_tid is already enabled) and gates on macOS 15+ via the `/etc/pam.d/sudo_local.template` check.

## Test plan
- [ ] Run `./gitops.sh` (dry-run) and confirm no validation errors.
- [ ] After merge + apply, verify "Enable Touch ID for sudo" appears under Self-service in Fleet Desktop on a Workstations host.
- [ ] Run it on a macOS 15+ host with Touch ID; confirm `/etc/pam.d/sudo_local` contains `auth sufficient pam_tid.so` and `sudo` prompts for Touch ID.
- [ ] Run it a second time; confirm idempotent "already enabled" exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)