### PR TITLE
Add Apple config profile and DDM doc references to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,19 @@
 # Fleet GitOps
 
-## Reference: YAML keys
+## References
 
-The full reference for all Fleet GitOps YAML keys (org settings, team settings, controls, policies, queries, software, etc.) is at:
+- **Fleet GitOps YAML keys** (org settings, team settings, controls, policies, queries, software, etc.):
+  https://fleetdm.com/docs/configuration/yaml-files
 
-https://fleetdm.com/docs/configuration/yaml-files
+  Consult these when adding, renaming, or validating any key before guessing at structure.
 
-Consult it when adding, renaming, or validating any key in this repo's YAML before guessing at structure.
+- **Apple configuration profile payload keys** (`.mobileconfig` payloads under `fleets/*/macos-settings/`):
+  https://developer.apple.com/documentation/devicemanagement/profile-specific-payload-keys
+
+  Consult this whenever authoring or editing a configuration profile — verify the payload type, keys, value types, and supported OS versions before writing or changing any payload.
+
+- **Apple Declarative Device Management (DDM)** declarations:
+  https://developer.apple.com/documentation/devicemanagement/declarations
+
+  Consult this whenever authoring or editing a DDM declaration — verify the declaration type, payload schema, and required/optional fields before writing or changing any declaration.
+


### PR DESCRIPTION
## Summary
- Adds Apple developer doc references for configuration profile payload keys and Declarative Device Management (DDM) declarations to CLAUDE.md
- Adds per-section guidance to consult the relevant Apple docs when authoring or editing config profiles / DDM declarations
- Restructures the existing Fleet YAML reference into a shared "References" list

## Test plan
- [ ] Render CLAUDE.md and confirm links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)