### PR TITLE
Restore patch policies for all Fleet-maintained macOS apps

### DIFF
--- a/platforms/macos/policies/macos-fma-patch.policies.yml
+++ b/platforms/macos/policies/macos-fma-patch.policies.yml
@@ -2,3 +2,135 @@
   type: patch
   fleet_maintained_app_slug: 1password/darwin
   install_software: true
+- name: balenaEtcher up to date
+  type: patch
+  fleet_maintained_app_slug: balenaetcher/darwin
+  install_software: true
+- name: Canva up to date
+  type: patch
+  fleet_maintained_app_slug: canva/darwin
+  install_software: true
+- name: Claude up to date
+  type: patch
+  fleet_maintained_app_slug: claude/darwin
+  install_software: true
+- name: CleanShot X up to date
+  type: patch
+  fleet_maintained_app_slug: cleanshot/darwin
+  install_software: true
+- name: Discord up to date
+  type: patch
+  fleet_maintained_app_slug: discord/darwin
+  install_software: true
+- name: Docker Desktop up to date
+  type: patch
+  fleet_maintained_app_slug: docker-desktop/darwin
+  install_software: true
+- name: Elgato Control Center up to date
+  type: patch
+  fleet_maintained_app_slug: elgato-control-center/darwin
+  install_software: true
+- name: Elgato Stream Deck up to date
+  type: patch
+  fleet_maintained_app_slug: elgato-stream-deck/darwin
+  install_software: true
+- name: Ghostty up to date
+  type: patch
+  fleet_maintained_app_slug: ghostty/darwin
+  install_software: true
+- name: GitHub Desktop up to date
+  type: patch
+  fleet_maintained_app_slug: github/darwin
+  install_software: true
+- name: Google Chrome up to date
+  type: patch
+  fleet_maintained_app_slug: google-chrome/darwin
+  install_software: true
+- name: Google Drive up to date
+  type: patch
+  fleet_maintained_app_slug: google-drive/darwin
+  install_software: true
+- name: GPG Suite up to date
+  type: patch
+  fleet_maintained_app_slug: gpg-suite/darwin
+  install_software: true
+- name: iMazing Profile Editor up to date
+  type: patch
+  fleet_maintained_app_slug: imazing-profile-editor/darwin
+  install_software: true
+- name: iTerm2 up to date
+  type: patch
+  fleet_maintained_app_slug: iterm2/darwin
+  install_software: true
+- name: Logi Options+ up to date
+  type: patch
+  fleet_maintained_app_slug: logi-options+/darwin
+  install_software: true
+- name: Visual Studio Code up to date
+  type: patch
+  fleet_maintained_app_slug: visual-studio-code/darwin
+  install_software: true
+- name: Notion up to date
+  type: patch
+  fleet_maintained_app_slug: notion/darwin
+  install_software: true
+- name: Ollama up to date
+  type: patch
+  fleet_maintained_app_slug: ollama/darwin
+  install_software: true
+- name: Postman up to date
+  type: patch
+  fleet_maintained_app_slug: postman/darwin
+  install_software: true
+- name: Raycast up to date
+  type: patch
+  fleet_maintained_app_slug: raycast/darwin
+  install_software: true
+- name: Signal up to date
+  type: patch
+  fleet_maintained_app_slug: signal/darwin
+  install_software: true
+- name: Slack up to date
+  type: patch
+  fleet_maintained_app_slug: slack/darwin
+  install_software: true
+- name: Sublime Text up to date
+  type: patch
+  fleet_maintained_app_slug: sublime-text/darwin
+  install_software: true
+- name: Suspicious Package up to date
+  type: patch
+  fleet_maintained_app_slug: suspicious-package/darwin
+  install_software: true
+- name: Tailscale up to date
+  type: patch
+  fleet_maintained_app_slug: tailscale-app/darwin
+  install_software: true
+- name: TextExpander up to date
+  type: patch
+  fleet_maintained_app_slug: textexpander/darwin
+  install_software: true
+- name: Transmit up to date
+  type: patch
+  fleet_maintained_app_slug: transmit/darwin
+  install_software: true
+- name: UTM up to date
+  type: patch
+  fleet_maintained_app_slug: utm/darwin
+  install_software: true
+- name: VLC up to date
+  type: patch
+  fleet_maintained_app_slug: vlc/darwin
+  install_software: true
+- name: WhatsApp up to date
+  type: patch
+  fleet_maintained_app_slug: whatsapp/darwin
+  install_software: true
+- name: Yubico Authenticator up to date
+  type: patch
+  fleet_maintained_app_slug: yubico-authenticator/darwin
+  install_software: true
+- name: Zoom up to date
+  type: patch
+  fleet_maintained_app_slug: zoom/darwin
+  install_software: true


### PR DESCRIPTION
## Summary
- Restores `type: patch` policies for all 34 Fleet-maintained macOS apps under `platforms/macos/policies/macos-fma-patch.policies.yml`
- Each policy references its FMA slug from `fleets/workstations.yml` with `install_software: true` so failing hosts get auto-patched

## Test plan
- [ ] `fleetctl gitops` apply succeeds with the workflow secrets loaded
- [ ] Patch policies appear in Fleet UI under the Workstations team and target hosts missing the latest FMA version

🤖 Generated with [Claude Code](https://claude.com/claude-code)