### PR TITLE
Bump macOS/iOS/iPadOS minimum version to 26.5

### DIFF
--- a/fleets/mobile-devices.yml
+++ b/fleets/mobile-devices.yml
@@ -15,11 +15,11 @@ agent_options:
 controls:
   enable_disk_encryption: true
   ios_updates:
-    deadline: "2026-05-04"
-    minimum_version: "26.4.2"
+    deadline: "2026-05-20"
+    minimum_version: "26.5"
   ipados_updates:
-    deadline: "2026-05-04"
-    minimum_version: "26.4.2"
+    deadline: "2026-05-20"
+    minimum_version: "26.5"
   apple_settings:
     configuration_profiles:
   scripts:

--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -12,8 +12,8 @@ agent_options:
 controls:
   enable_disk_encryption: true
   macos_updates:
-    deadline: '2026-05-04'
-    minimum_version: '26.4.1'
+    deadline: '2026-05-20'
+    minimum_version: '26.5'
   apple_settings:
     configuration_profiles:
     - path: ../platforms/macos/configuration-profiles/macos-password.mobileconfig


### PR DESCRIPTION
## Summary
- Update `macos_updates`, `ios_updates`, and `ipados_updates` minimum version to `26.5` (released 2026-05-11)
- Set enforcement deadline to `2026-05-20` (7 days out)

## Test plan
- [x] `fleetctl gitops` dry-run passes in CI
- [x] Confirm in Fleet UI that the workstations and mobile-devices fleets show the new minimum version and deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)