### PR TITLE
Fix policy queries broken by DDM migration

### DIFF
--- a/platforms/macos/policies/macos-device-health.policies.yml
+++ b/platforms/macos/policies/macos-device-health.policies.yml
@@ -23,60 +23,50 @@
 - name: macOS - Require 8 character password
   platform: darwin
   description: This policy checks if the end user is required to enter a password, with at least 8 characters, to unlock the host.
-  resolution: An an IT admin, deploy a macOS, screensaver profile with the askForPassword option set to true and minLength option set to 10.
+  resolution: As an IT admin, deploy or update the DDM passcode declaration (platforms/macos/declaration-profiles/passcode-settings-ddm.json) with MinimumLength set to at least 8.
   query: |
-    SELECT 1 WHERE 
-      EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.screensaver' AND 
-            name='askForPassword' AND 
-            CAST(value AS INT)
-        )
-      AND EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.screensaver' AND 
-            name='minLength' AND 
-            CAST(value AS INT) <= 8
-        );
+    SELECT 1 FROM password_policy
+    WHERE policy_category = 'passwordPolicyPasswordContent'
+      AND (policy_content LIKE '%.{8,}%' OR policy_parameters LIKE '%"minimumLength":8%');
 
 - name: macOS - Software Update - Disallow pre-release installation
   platform: darwin
   description: This policy checks that pre-release macOS updates are not offered to users.
-  resolution: As an IT admin, deploy or update a macOS Software Update profile (domain com.apple.SoftwareUpdate) with AllowPreReleaseInstallation set to false at the system scope.
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND username='' AND name='AllowPreReleaseInstallation' AND CAST(value AS INT)=0;
+  resolution: As an IT admin, deploy or update the DDM software update declaration (platforms/macos/declaration-profiles/softwareupdate-settings-ddm.json) with AllowPreReleaseInstallation set to false.
+  query: SELECT 1 FROM preferences WHERE domain='com.apple.SoftwareUpdate' AND username='' AND key='AllowPreReleaseInstallation' AND CAST(value AS INT)=0;
 
 - name: macOS - Software Update - Automatic check enabled
   platform: darwin
   description: This policy checks that the system automatically checks for software updates.
-  resolution: As an IT admin, deploy or update a macOS Software Update profile (domain com.apple.SoftwareUpdate) with AutomaticCheckEnabled set to true at the system scope.
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND username='' AND name='AutomaticCheckEnabled' AND CAST(value AS INT)=1;
+  resolution: As an IT admin, verify the DDM software update declaration is delivered. On modern macOS the system enforces automatic checks under DDM by default; if this fails, investigate why CFPreferences reports it disabled.
+  query: SELECT 1 FROM preferences WHERE domain='com.apple.SoftwareUpdate' AND username='' AND key='AutomaticCheckEnabled' AND CAST(value AS INT)=1;
 
 - name: macOS - Software Update - Automatic download enabled
   platform: darwin
   description: This policy checks that available updates are downloaded automatically.
-  resolution: As an IT admin, deploy or update a macOS Software Update profile (domain com.apple.SoftwareUpdate) with AutomaticDownload set to true at the system scope.
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND username='' AND name='AutomaticDownload' AND CAST(value AS INT)=1;
+  resolution: As an IT admin, deploy or update the DDM software update declaration (platforms/macos/declaration-profiles/softwareupdate-settings-ddm.json) with Automatic.Download set to true.
+  query: SELECT 1 FROM preferences WHERE domain='com.apple.SoftwareUpdate' AND username='' AND key='AutomaticDownload' AND CAST(value AS INT)=1;
 
 - name: macOS - Software Update - Auto-install App Store updates
   platform: darwin
   description: This policy checks that App Store updates are auto-installed.
-  resolution: As an IT admin, deploy or update a macOS Software Update profile (domain com.apple.SoftwareUpdate) with AutomaticallyInstallAppUpdates set to true at the system scope.
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND username='' AND name='AutomaticallyInstallAppUpdates' AND CAST(value AS INT)=1;
+  resolution: As an IT admin, deploy or update the DDM software update declaration (platforms/macos/declaration-profiles/softwareupdate-settings-ddm.json) with Automatic.InstallAppUpdates set to true.
+  query: SELECT 1 FROM preferences WHERE domain='com.apple.SoftwareUpdate' AND username='' AND key='AutomaticallyInstallAppUpdates' AND CAST(value AS INT)=1;
 
 - name: macOS - Software Update - Do not auto-install macOS updates
   platform: darwin
   description: This policy checks that macOS updates are not auto-installed (installation remains admin-driven).
-  resolution: As an IT admin, deploy or update a macOS Software Update profile (domain com.apple.SoftwareUpdate) with AutomaticallyInstallMacOSUpdates set to false at the system scope.
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND username='' AND name='AutomaticallyInstallMacOSUpdates' AND CAST(value AS INT)=0;
+  resolution: As an IT admin, deploy or update the DDM software update declaration (platforms/macos/declaration-profiles/softwareupdate-settings-ddm.json) with Automatic.InstallOSUpdates set to false.
+  query: SELECT 1 FROM preferences WHERE domain='com.apple.SoftwareUpdate' AND username='' AND key='AutomaticallyInstallMacOSUpdates' AND CAST(value AS INT)=0;
 
 - name: macOS - Software Update - Install configuration data
   platform: darwin
   description: This policy checks that system data files and security configuration updates are enabled.
-  resolution: As an IT admin, deploy or update a macOS Software Update profile (domain com.apple.SoftwareUpdate) with ConfigDataInstall set to true at the system scope.
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND username='' AND name='ConfigDataInstall' AND CAST(value AS INT)=1;
+  resolution: As an IT admin, verify the DDM software update declaration is delivered. ConfigDataInstall is implicit under DDM Automatic.InstallSecurityUpdate; if this fails, investigate why CFPreferences reports it disabled.
+  query: SELECT 1 FROM preferences WHERE domain='com.apple.SoftwareUpdate' AND username='' AND key='ConfigDataInstall' AND CAST(value AS INT)=1;
 
 - name: macOS - Software Update - Install critical updates
   platform: darwin
   description: This policy checks that critical updates are installed automatically.
-  resolution: As an IT admin, deploy or update a macOS Software Update profile (domain com.apple.SoftwareUpdate) with CriticalUpdateInstall set to true at the system scope.
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND username='' AND name='CriticalUpdateInstall' AND CAST(value AS INT)=1;
+  resolution: As an IT admin, deploy or update the DDM software update declaration (platforms/macos/declaration-profiles/softwareupdate-settings-ddm.json) with Automatic.InstallSecurityUpdate set to true.
+  query: SELECT 1 FROM preferences WHERE domain='com.apple.SoftwareUpdate' AND username='' AND key='CriticalUpdateInstall' AND CAST(value AS INT)=1;


### PR DESCRIPTION
## Summary

After #156 migrated the passcode and software update settings from `.mobileconfig` profiles to DDM declarations, the eight related policies in `platforms/macos/policies/macos-device-health.policies.yml` started failing on every host. Root cause: `managed_policies` reads `/Library/Managed Preferences/<domain>.plist`, which only the legacy MCX/profile path populates. DDM declarations are enforced through Apple's DeclarativeManagement framework and don't write there — so every `SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' ...` returns zero rows even though the setting is in force.

This PR rewrites the affected queries to read from tables that DDM-applied settings actually surface in:

- **`macOS - Require 8 character password`** → `password_policy` table (OpenDirectory account policies, where DDM `com.apple.configuration.passcode.settings` lands via `pwpolicy`). Matches either the content regex `.{8,}` or `policy_parameters` JSON containing `"minimumLength":8`.
- **All 6 `macOS - Software Update - *` policies** → `preferences` table (effective CFPreferences value for `com.apple.SoftwareUpdate`). Constrained to `username=''` per the requirement documented at https://fleetdm.com/tables/preferences.
- Resolution text now points at the DDM declaration files (`platforms/macos/declaration-profiles/*-ddm.json`) instead of the deleted mobileconfigs.

Two of the policies (`Automatic check enabled`, `Install configuration data`) have no direct key in `com.apple.configuration.softwareupdate.settings` — those settings are implicit/always-on under modern macOS DDM. The queries check the effective CFPreferences value, which is typically `true` by default on managed hosts; if they fail in practice they're candidates for deletion as obsolete.

## Test plan

- [ ] Run `fleetctl gitops --dry-run` against the repo and confirm the workflow validates.
- [ ] On a DDM-enrolled Mac, run live queries to confirm the new tables return the expected rows:
  - `SELECT * FROM preferences WHERE domain='com.apple.SoftwareUpdate' AND username='';`
  - `SELECT policy_category, policy_identifier, policy_content, policy_parameters FROM password_policy WHERE policy_category='passwordPolicyPasswordContent';`
- [ ] After merge, watch the Fleet UI for the eight policies to flip from Fail to Pass on enrolled hosts.
- [ ] If `preferences` returns no rows for a SoftwareUpdate key on macOS 26.x, DDM isn't writing through that key on this OS version — fall back to a `forced=1` filter (would require DDM writing to `/Library/Managed Preferences/`) or to a different probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)