### PR TITLE
Enforce GuestEnabled=false via LaunchDaemon to defeat macOS 26 override

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -41,7 +41,8 @@ controls:
     - path: ../platforms/macos/configuration-profiles/disable-content-caching.mobileconfig
       labels_include_any:
       - macOS hosts
-  scripts: null
+  scripts:
+  - path: ../platforms/macos/scripts/disable-guest-enforce.sh
 settings:
   secrets:
   - secret: $FLEET_WORKSTATIONS_ENROLL_SECRET

--- a/platforms/macos/policies/macos-device-health.policies.yml
+++ b/platforms/macos/policies/macos-device-health.policies.yml
@@ -32,8 +32,10 @@
 - name: macOS - Disable Guest user
   platform: darwin
   description: |
-    Checks that the Disable Guest User configuration profile is delivered and fully applied. The profile layers two payloads: the NIST mSCP-recommended com.apple.MCX keys (DisableGuestAccount=true, EnableGuestAccount=false), and a com.apple.ManagedClient.preferences payload that forces com.apple.loginwindow GuestEnabled=false. The loginwindow key is what macOS 26's Users & Groups UI actually reads when greying out the "Allow guests to log in to this computer" toggle, so all three managed values must be present for compliance.
-  resolution: As an IT admin, deploy the Disable Guest User profile (platforms/macos/configuration-profiles/disable-guest.mobileconfig) and confirm it shows as verified in the host's MDM panel.
+    Verifies guest access is effectively disabled. Two layers must hold: (1) the Disable Guest User configuration profile is delivered and projecting com.apple.MCX (DisableGuestAccount=true, EnableGuestAccount=false) plus a com.apple.loginwindow Forced GuestEnabled=false, and (2) the on-disk /Library/Preferences/com.apple.loginwindow.plist does not have GuestEnabled set to true. On macOS 26 the Users & Groups UI writes the unmanaged GuestEnabled key and macOS honors that user-level value despite the managed pref, so the live plist must also be checked. The disable-guest-enforce.sh remediation installs a LaunchDaemon that reverts the unmanaged value whenever it changes.
+  resolution: As an IT admin, deploy the Disable Guest User profile (platforms/macos/configuration-profiles/disable-guest.mobileconfig). Fleet will auto-run platforms/macos/scripts/disable-guest-enforce.sh on failure to install/refresh the enforcement LaunchDaemon.
+  run_script:
+    path: ../scripts/disable-guest-enforce.sh
   query: |
     SELECT 1
     WHERE EXISTS (
@@ -50,6 +52,12 @@
       SELECT 1 FROM managed_policies
       WHERE domain = 'com.apple.loginwindow' AND username = ''
         AND name = 'GuestEnabled' AND CAST(value AS INT) = 0
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM plist
+      WHERE path = '/Library/Preferences/com.apple.loginwindow.plist'
+        AND key = 'GuestEnabled'
+        AND value IN ('true', '1')
     );
 
 - name: macOS - Software Update settings DDM declaration active

--- a/platforms/macos/scripts/disable-guest-enforce.sh
+++ b/platforms/macos/scripts/disable-guest-enforce.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Installs a LaunchDaemon that re-asserts GuestEnabled=false on the
+# loginwindow preferences plist whenever it is modified.
+#
+# Why this exists: on macOS 26 (Tahoe) the System Settings -> Users &
+# Groups -> "Allow guests to log in to this computer" toggle writes
+# directly to /Library/Preferences/com.apple.loginwindow GuestEnabled,
+# and the OS honors that user-level write even when a managed
+# preference (com.apple.loginwindow Forced GuestEnabled=false, delivered
+# by disable-guest.mobileconfig) says otherwise. The com.apple.MCX
+# DisableGuestAccount key is still honored by loginwindow itself, but
+# nothing prevents the toggle from flipping in the UI. This daemon
+# closes that gap by reverting the plist within ~1s of any change.
+
+set -euo pipefail
+
+if [[ $(id -u) -ne 0 ]]; then
+  echo "[disable-guest-enforce] must run as root (Fleet scripts run as root)"
+  exit 1
+fi
+
+DAEMON_LABEL="net.kitzy.disable-guest-enforce"
+DAEMON_PLIST="/Library/LaunchDaemons/${DAEMON_LABEL}.plist"
+HELPER_SCRIPT="/usr/local/bin/disable-guest-enforce.sh"
+
+mkdir -p /usr/local/bin
+
+cat > "$HELPER_SCRIPT" <<'HELPER'
+#!/bin/bash
+# Reverts the guest-related preferences that the macOS 26 Users & Groups
+# UI lets the local user toggle on despite the managed configuration
+# profile. Triggered by the WatchPaths in net.kitzy.disable-guest-enforce.
+defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool false
+defaults write /Library/Preferences/com.apple.AppleFileServer guestAccess -bool false 2>/dev/null || true
+defaults write /Library/Preferences/SystemConfiguration/com.apple.smb.server AllowGuestAccess -bool false 2>/dev/null || true
+HELPER
+chmod 755 "$HELPER_SCRIPT"
+chown root:wheel "$HELPER_SCRIPT"
+
+cat > "$DAEMON_PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${DAEMON_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${HELPER_SCRIPT}</string>
+  </array>
+  <key>WatchPaths</key>
+  <array>
+    <string>/Library/Preferences/com.apple.loginwindow.plist</string>
+    <string>/Library/Preferences/com.apple.AppleFileServer.plist</string>
+    <string>/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>2</integer>
+  <key>StandardOutPath</key>
+  <string>/var/log/disable-guest-enforce.log</string>
+  <key>StandardErrorPath</key>
+  <string>/var/log/disable-guest-enforce.log</string>
+</dict>
+</plist>
+PLIST
+chmod 644 "$DAEMON_PLIST"
+chown root:wheel "$DAEMON_PLIST"
+
+launchctl bootout system "$DAEMON_PLIST" 2>/dev/null || true
+launchctl bootstrap system "$DAEMON_PLIST"
+launchctl kickstart -k "system/${DAEMON_LABEL}"
+
+echo "[disable-guest-enforce] installed ${DAEMON_LABEL} and re-asserted guest preferences"


### PR DESCRIPTION
Diagnosis on a UAMDM macOS 26 host showed all three managed values project correctly (com.apple.MCX.DisableGuestAccount=1, com.apple.MCX.EnableGuestAccount=0, com.apple.loginwindow.GuestEnabled=0 under /Library/Managed Preferences) yet flipping the Users & Groups "Allow guests to log in to this computer" toggle and clicking OK writes GuestEnabled=1 into /Library/Preferences/com.apple.loginwindow and macOS keeps that user-level value. The managed pref no longer wins for this key, so the configuration profile alone can't enforce.

Add a Fleet-deployed script (disable-guest-enforce.sh) that installs a LaunchDaemon (net.kitzy.disable-guest-enforce) with WatchPaths on the loginwindow, AppleFileServer, and smb.server preference files. RunAtLoad reverts the current state immediately and any subsequent modification re-fires the helper within ~1s.

Extend the macOS - Disable Guest user policy to also fail when the on-disk loginwindow plist has GuestEnabled=true, and wire run_script to the new installer so the daemon self-heals when missing. Register the script in fleets/workstations.yml so Fleet can invoke it from policy automation.