### PR TITLE
Add labels for the past five macOS major versions

### DIFF
--- a/labels/operating-systems.yml
+++ b/labels/operating-systems.yml
@@ -2,6 +2,26 @@
   description: All macOS hosts
   query: SELECT 1 FROM os_version WHERE platform = 'darwin';
   label_membership_type: dynamic
+- name: macOS 26 Tahoe
+  description: All macOS hosts running macOS 26 (Tahoe)
+  query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major = 26;
+  label_membership_type: dynamic
+- name: macOS 15 Sequoia
+  description: All macOS hosts running macOS 15 (Sequoia)
+  query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major = 15;
+  label_membership_type: dynamic
+- name: macOS 14 Sonoma
+  description: All macOS hosts running macOS 14 (Sonoma)
+  query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major = 14;
+  label_membership_type: dynamic
+- name: macOS 13 Ventura
+  description: All macOS hosts running macOS 13 (Ventura)
+  query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major = 13;
+  label_membership_type: dynamic
+- name: macOS 12 Monterey
+  description: All macOS hosts running macOS 12 (Monterey)
+  query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major = 12;
+  label_membership_type: dynamic
 - name: Ubuntu Linux hosts
   description: All Ubuntu Linux hosts
   query: SELECT 1 FROM os_version WHERE platform = 'ubuntu';


### PR DESCRIPTION
## Summary
- Adds dynamic labels for macOS 26 (Tahoe), 15 (Sequoia), 14 (Sonoma), 13 (Ventura), and 12 (Monterey)
- Keyed off `os_version.major` so hosts can be targeted or filtered by major macOS version
- Picked up automatically by `default.yml`'s `labels/*.yml` aggregation — no wiring required

## Test plan
- [x] `fleetctl gitops` apply succeeds
- [x] Each new label appears in Fleet and dynamically populates with the expected hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)