### PR TITLE
Add iOS, iPadOS, Windows, Android labels; rename to avoid built-in collisions

### DIFF
--- a/fleets/servers.yml
+++ b/fleets/servers.yml
@@ -25,10 +25,10 @@ controls:
     configuration_profiles:
     - path: ../platforms/macos/configuration-profiles/fleetd-full-disk-access.mobileconfig
       labels_include_any:
-      - macOS
+      - macOS hosts
     - path: ../platforms/all/declaration-profiles/disable-beta-updates-ddm.json
       labels_include_any:
-      - macOS
+      - macOS hosts
 settings:
   secrets:
     - secret: "$FLEET_SERVERS_ENROLL_SECRET"

--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -19,28 +19,28 @@ controls:
     configuration_profiles:
     - path: ../platforms/macos/declaration-profiles/passcode-settings-ddm.json
       labels_include_any:
-      - macOS
+      - macOS hosts
     - path: ../platforms/macos/declaration-profiles/softwareupdate-settings-ddm.json
       labels_include_any:
-      - macOS
+      - macOS hosts
     - path: ../platforms/macos/configuration-profiles/macos-firewall.mobileconfig
       labels_include_any:
-      - macOS
+      - macOS hosts
     - path: ../platforms/macos/configuration-profiles/disable-guest.mobileconfig
       labels_include_any:
-      - macOS
+      - macOS hosts
     - path: ../platforms/macos/configuration-profiles/chrome-disable-password-manager.mobileconfig
       labels_include_any:
-      - macOS
+      - macOS hosts
     - path: ../platforms/macos/configuration-profiles/fleet-background-activity.mobileconfig
       labels_include_any:
-      - macOS
+      - macOS hosts
     - path: ../platforms/macos/configuration-profiles/fleetd-full-disk-access.mobileconfig
       labels_include_any:
-      - macOS
+      - macOS hosts
     - path: ../platforms/macos/configuration-profiles/disable-content-caching.mobileconfig
       labels_include_any:
-      - macOS
+      - macOS hosts
   scripts: null
 settings:
   secrets:

--- a/labels/operating-systems.yml
+++ b/labels/operating-systems.yml
@@ -1,3 +1,7 @@
+- name: macOS hosts
+  description: All macOS hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'darwin';
+  label_membership_type: dynamic
 - name: macOS 26 Tahoe
   description: All macOS hosts running macOS 26 (Tahoe)
   query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major = 26;
@@ -22,7 +26,19 @@
   description: AUbuntu Linux hosts
   query: SELECT 1 FROM os_version WHERE platform = 'ubuntu';
   label_membership_type: dynamic
-- name: Windows
+- name: iOS hosts
+  description: All iOS hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'ios';
+  label_membership_type: dynamic
+- name: iPadOS hosts
+  description: All iPadOS hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'ipados';
+  label_membership_type: dynamic
+- name: Windows hosts
   description: All Windows hosts
   query: SELECT 1 FROM os_version WHERE platform = 'windows';
+  label_membership_type: dynamic
+- name: Android hosts
+  description: All Android hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'android';
   label_membership_type: dynamic

--- a/labels/operating-systems.yml
+++ b/labels/operating-systems.yml
@@ -1,7 +1,3 @@
-- name: macOS
-  description: All macOS hosts
-  query: SELECT 1 FROM os_version WHERE platform = 'darwin';
-  label_membership_type: dynamic
 - name: macOS 26 Tahoe
   description: All macOS hosts running macOS 26 (Tahoe)
   query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major = 26;
@@ -26,19 +22,7 @@
   description: AUbuntu Linux hosts
   query: SELECT 1 FROM os_version WHERE platform = 'ubuntu';
   label_membership_type: dynamic
-- name: iOS
-  description: All iOS hosts
-  query: SELECT 1 FROM os_version WHERE platform = 'ios';
-  label_membership_type: dynamic
-- name: iPadOS
-  description: All iPadOS hosts
-  query: SELECT 1 FROM os_version WHERE platform = 'ipados';
-  label_membership_type: dynamic
 - name: Windows
   description: All Windows hosts
   query: SELECT 1 FROM os_version WHERE platform = 'windows';
-  label_membership_type: dynamic
-- name: Android
-  description: All Android hosts
-  query: SELECT 1 FROM os_version WHERE platform = 'android';
   label_membership_type: dynamic

--- a/labels/operating-systems.yml
+++ b/labels/operating-systems.yml
@@ -26,3 +26,19 @@
   description: AUbuntu Linux hosts
   query: SELECT 1 FROM os_version WHERE platform = 'ubuntu';
   label_membership_type: dynamic
+- name: iOS
+  description: All iOS hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'ios';
+  label_membership_type: dynamic
+- name: iPadOS
+  description: All iPadOS hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'ipados';
+  label_membership_type: dynamic
+- name: Windows
+  description: All Windows hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'windows';
+  label_membership_type: dynamic
+- name: Android
+  description: All Android hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'android';
+  label_membership_type: dynamic

--- a/labels/operating-systems.yml
+++ b/labels/operating-systems.yml
@@ -23,7 +23,7 @@
   query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND major = 12;
   label_membership_type: dynamic
 - name: Ubuntu
-  description: AUbuntu Linux hosts
+  description: All Ubuntu Linux hosts
   query: SELECT 1 FROM os_version WHERE platform = 'ubuntu';
   label_membership_type: dynamic
 - name: iOS hosts


### PR DESCRIPTION
## Summary
Fleet enforces two rules around built-in label names:
1. You cannot **create** a custom label whose name matches a built-in (HTTP 422 on `POST /api/latest/fleet/spec/labels`).
2. You cannot **reference** a built-in label in `labels_include_any` — only custom labels are supported there.

`macOS`, `iOS`, `iPadOS`, and `Android` are all built-in. Our existing custom `macOS` label (added in #166) now collides, and the new `iOS`/`iPadOS`/`Android` labels can't use the obvious names either.

### Changes
- Rename `macOS` → `macOS hosts` in [labels/operating-systems.yml](labels/operating-systems.yml) and update every `labels_include_any` reference in [fleets/workstations.yml](fleets/workstations.yml) and [fleets/servers.yml](fleets/servers.yml).
- Add `iOS hosts`, `iPadOS hosts`, `Android hosts`, `Windows hosts` using the same suffix convention.
- Keep `Ubuntu` (built-in is `Ubuntu Linux`, no collision) and all version-specific `macOS NN <codename>` labels.

## Test plan
- [ ] `fleetctl gitops` applies cleanly
- [ ] Hosts previously in custom `macOS` are reachable via `macOS hosts`; macOS configuration profiles still deploy to the expected hosts
- [ ] `iOS hosts`, `iPadOS hosts`, `Windows hosts`, `Android hosts` each populate with the expected hosts in Fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)