### PR TITLE
Add architecture, form-factor, virtualization, and OS-version labels

### DIFF
--- a/labels/hardware.yml
+++ b/labels/hardware.yml
@@ -1,0 +1,20 @@
+- name: Apple Silicon
+  description: All macOS hosts running on Apple Silicon (arm64)
+  query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND arch = 'arm64';
+  label_membership_type: dynamic
+- name: Intel Mac
+  description: All macOS hosts running on Intel (x86_64)
+  query: SELECT 1 FROM os_version WHERE platform = 'darwin' AND arch = 'x86_64';
+  label_membership_type: dynamic
+- name: MacBook
+  description: Portable Macs (MacBook, MacBook Air, MacBook Pro)
+  query: SELECT 1 FROM system_info WHERE hardware_model LIKE 'MacBook%';
+  label_membership_type: dynamic
+- name: Desktop Mac
+  description: Non-portable Macs (iMac, Mac mini, Mac Studio, Mac Pro)
+  query: SELECT 1 FROM os_version, system_info WHERE os_version.platform = 'darwin' AND system_info.hardware_model NOT LIKE 'MacBook%';
+  label_membership_type: dynamic
+- name: Virtual machine
+  description: Hosts running in a virtual machine (VMware, Parallels, QEMU, VirtualBox, Hyper-V, Xen)
+  query: SELECT 1 FROM system_info WHERE hardware_vendor LIKE '%VMware%' OR hardware_vendor LIKE '%Parallels%' OR hardware_vendor LIKE '%QEMU%' OR hardware_vendor LIKE '%innotek%' OR hardware_vendor LIKE 'Xen%' OR hardware_model LIKE 'Virtual Machine%' OR hardware_model LIKE 'VirtualBox%';
+  label_membership_type: dynamic

--- a/labels/operating-systems.yml
+++ b/labels/operating-systems.yml
@@ -26,6 +26,18 @@
   description: All Ubuntu Linux hosts
   query: SELECT 1 FROM os_version WHERE platform = 'ubuntu';
   label_membership_type: dynamic
+- name: Ubuntu 24.04
+  description: All Ubuntu 24.04 (Noble Numbat) hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'ubuntu' AND major = 24 AND minor = 4;
+  label_membership_type: dynamic
+- name: Ubuntu 22.04
+  description: All Ubuntu 22.04 (Jammy Jellyfish) hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'ubuntu' AND major = 22 AND minor = 4;
+  label_membership_type: dynamic
+- name: Ubuntu 20.04
+  description: All Ubuntu 20.04 (Focal Fossa) hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'ubuntu' AND major = 20 AND minor = 4;
+  label_membership_type: dynamic
 - name: iOS hosts
   description: All iOS hosts
   query: SELECT 1 FROM os_version WHERE platform = 'ios';
@@ -37,6 +49,18 @@
 - name: Windows hosts
   description: All Windows hosts
   query: SELECT 1 FROM os_version WHERE platform = 'windows';
+  label_membership_type: dynamic
+- name: Windows 11
+  description: All Windows 11 hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'windows' AND name LIKE 'Microsoft Windows 11%';
+  label_membership_type: dynamic
+- name: Windows 10
+  description: All Windows 10 hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'windows' AND name LIKE 'Microsoft Windows 10%';
+  label_membership_type: dynamic
+- name: Windows Server
+  description: All Windows Server hosts
+  query: SELECT 1 FROM os_version WHERE platform = 'windows' AND name LIKE '%Server%';
   label_membership_type: dynamic
 - name: Android hosts
   description: All Android hosts


### PR DESCRIPTION
## Summary
Adds higher-resolution labels for targeting policies, profiles, and software:

- **OS version splits** in [labels/operating-systems.yml](labels/operating-systems.yml):
  - `Ubuntu 24.04`, `Ubuntu 22.04`, `Ubuntu 20.04` — current LTS releases, mirror the per-major macOS labels.
  - `Windows 11`, `Windows 10`, `Windows Server` — split by `os_version.name` (Windows 11 still reports `major=10`, so `name` is the reliable signal).
- **New** [labels/hardware.yml](labels/hardware.yml) (auto-loaded by `default.yml`'s `labels/*.yml` glob):
  - `Apple Silicon` / `Intel Mac` — split by `os_version.arch` (`arm64` vs `x86_64`).
  - `MacBook` / `Desktop Mac` — split by `system_info.hardware_model` for portable-vs-non-portable scoping.
  - `Virtual machine` — catches VMware, Parallels, QEMU, VirtualBox, Hyper-V, and Xen via `system_info.hardware_vendor` / `hardware_model`.

All names avoid the Fleet built-in label collision list.

## Test plan
- [ ] `fleetctl gitops` applies cleanly
- [ ] Each Ubuntu / Windows version label populates with the expected hosts
- [ ] `Apple Silicon` + `Intel Mac` partition all macOS hosts
- [ ] `MacBook` + `Desktop Mac` partition all macOS hosts
- [ ] `Virtual machine` matches any VM hosts in the fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)