### PR TITLE
Add reference to Fleet host vitals table schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,3 +54,7 @@
 
   Consult this whenever authoring or editing an osquery SQL query — verify each table referenced in `FROM` / `JOIN` clauses, the platforms it supports, and the columns/types you're selecting on. Fleet's schema differs from upstream osquery (platform availability, deprecated columns, Fleet-specific extensions like `mdm`, `network_interfaces`, etc.).
 
+- **Fleet host vitals table schema** (tables and columns available to queries in policies, reports, labels, and inline `query:` fields):
+  https://fleetdm.com/vitals
+
+  Consult this whenever authoring or editing an osquery SQL query — verify each table referenced in `FROM` / `JOIN` clauses, the platforms it supports, and the columns/types you're selecting on. Fleet's schema differs from upstream osquery (platform availability, deprecated columns, Fleet-specific extensions like `mdm`, `network_interfaces`, etc.).


### PR DESCRIPTION
Added a reference to the Fleet host vitals table schema for better clarity when authoring SQL queries.