### PR TITLE
Enable vulnerability exposure dashboard chart for all fleets

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -19,6 +19,8 @@ org_settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
+    historical_data:
+      vulnerabilities: true
   fleet_desktop:
     transparency_url: 
   host_expiry_settings:

--- a/fleets/autopkg-testing.yml
+++ b/fleets/autopkg-testing.yml
@@ -10,4 +10,6 @@ settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
+    historical_data:
+      vulnerabilities: true
 software:

--- a/fleets/mobile-devices.yml
+++ b/fleets/mobile-devices.yml
@@ -30,4 +30,6 @@ settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
+    historical_data:
+      vulnerabilities: true
 software:

--- a/fleets/servers.yml
+++ b/fleets/servers.yml
@@ -41,4 +41,6 @@ settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
+    historical_data:
+      vulnerabilities: true
 software:

--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -60,6 +60,8 @@ settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
+    historical_data:
+      vulnerabilities: true
 software:
   packages:
   - path: ../platforms/macos/scripts/enable-touch-id-sudo.sh


### PR DESCRIPTION
## Summary

- Sets `features.historical_data.vulnerabilities: true` on the global config ([default.yml](default.yml)) and on every fleet under `fleets/` so the Fleet 4.85+ "Vulnerability exposure" dashboard chart starts collecting historical CVE data.
- Effective-collection is `global AND per-fleet`, so the key is set in both places. `fleets/unassigned.yml` is left untouched — it has no `settings.features` block and Unassigned hosts inherit the global value per Fleet's spec.

## Notes

- Requires Fleet **4.85.0+** on the server; older versions will reject `historical_data` as an unknown key.
- Fleet's 4.85 release notes call out a performance caveat above ~1,000 hosts. Well below that here, but worth flagging if the fleet grows.
- Leaving the key out of GitOps YAML is a no-op in 4.85 (won't auto-enable or disable), which is why the explicit `true` is needed.

## Test plan

- [ ] `fleetctl gitops` apply succeeds on the target Fleet instance
- [ ] Fleet UI → Settings → Advanced → "Disable vulnerabilities" is **unchecked** after apply
- [ ] Vulnerability exposure chart appears on the dashboard and begins collecting data

🤖 Generated with [Claude Code](https://claude.com/claude-code)