### PR TITLE
Enable host expiry at 90 days

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -24,8 +24,8 @@ org_settings:
   fleet_desktop:
     transparency_url: 
   host_expiry_settings:
-    host_expiry_enabled: false
-    host_expiry_window: 0
+    host_expiry_enabled: true
+    host_expiry_window: 90
   integrations:
     conditional_access_enabled:
     google_calendar:


### PR DESCRIPTION
## Summary

- Flips `host_expiry_enabled` to `true` and sets `host_expiry_window: 90` in [default.yml](default.yml) so hosts that haven't checked in for 90 days are automatically removed from Fleet.
- Keeps the inventory aligned with what's actually online — reduces stale-host noise in dashboards, policy compliance counts, and license usage.

## Test plan

- [ ] `fleetctl gitops` apply succeeds on the target Fleet instance
- [ ] Fleet UI → Settings → Organization settings → Host expiry shows **Enabled** at **90 days**
- [ ] After the next scheduled cleanup run, any hosts not seen in >90 days are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)