### PR TITLE
Add macOS CIS hardening profiles to workstations

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -56,6 +56,36 @@ controls:
     - path: ../platforms/macos/configuration-profiles/disable-content-caching.mobileconfig
       labels_include_any:
       - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/disable-bluetooth-file-sharing.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/disable-internet-sharing.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/disable-media-sharing.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/disable-safari-safefiles.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/enforce-library-validation.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/prevent-autologon.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/limit-ad-tracking.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/date-time.mobileconfig
+      labels_include_any:
+      - macOS hosts
+    - path: ../platforms/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
+      labels_include_any:
+      - macOS hosts
   scripts: null
 settings:
   secrets:

--- a/platforms/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
+++ b/platforms/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>Enables App Store automatic updates.</string>
+	<key>PayloadDisplayName</key>
+	<string>Automatic App Store updates</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.appstore-auto-updates</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>79C22B1E-4E32-4A72-B1AF-B8A3E93DAADB</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>AutomaticallyInstallAppUpdates</key>
+			<true/>
+			<key>PayloadDescription</key>
+			<string>Automatically install App Store updates</string>
+			<key>PayloadDisplayName</key>
+			<string>Automatically install App Store updates</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.macos.appstore-auto-updates.payload</string>
+			<key>PayloadOrganization</key>
+			<string>Kitzy.net</string>
+			<key>PayloadType</key>
+			<string>com.apple.SoftwareUpdate</string>
+			<key>PayloadUUID</key>
+			<string>CC66B236-BFF0-4374-8A80-C36C02D19F0E</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/date-time.mobileconfig
+++ b/platforms/macos/configuration-profiles/date-time.mobileconfig
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — enforces automatic date and time.</string>
+	<key>PayloadDisplayName</key>
+	<string>Automatic date and time</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.date-time</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>97C5B239-11B6-46D4-980F-EB72DF6DD1A3</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Force automatic date and time</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadUUID</key>
+			<string>8CF070CD-9013-44B0-96C3-85D6BD1ED429</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>forceAutomaticDateAndTime</key>
+			<true/>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/disable-bluetooth-file-sharing.mobileconfig
+++ b/platforms/macos/configuration-profiles/disable-bluetooth-file-sharing.mobileconfig
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — disables Bluetooth Sharing.</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable Bluetooth sharing</string>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.bluetooth-sharing</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>E504140D-E65A-4274-B7CD-D6544AE5D400</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadContent</key>
+			<dict>
+				<key>com.apple.Bluetooth</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>PrefKeyServicesEnabled</key>
+								<false/>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Disables Bluetooth Sharing</string>
+			<key>PayloadDisplayName</key>
+			<string>Custom</string>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.macos.cis.bluetooth-sharing.payload</string>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadUUID</key>
+			<string>4E26AE8D-36A0-46EA-999F-975F4C196EA0</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/disable-internet-sharing.mobileconfig
+++ b/platforms/macos/configuration-profiles/disable-internet-sharing.mobileconfig
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — forces Internet Sharing off.</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable internet sharing</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.internet-sharing</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>8C31A271-7EE4-40D5-BC66-C695E725ECFB</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Ensure Internet Sharing Is Disabled</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.macos.cis.internet-sharing.payload</string>
+			<key>PayloadType</key>
+			<string>com.apple.MCX</string>
+			<key>PayloadUUID</key>
+			<string>3309736D-3345-479A-B1F2-0266FCD53FF4</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>forceInternetSharingOff</key>
+			<true/>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/disable-media-sharing.mobileconfig
+++ b/platforms/macos/configuration-profiles/disable-media-sharing.mobileconfig
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — disables Media Sharing (Home, Legacy, Media).</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable media sharing</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.media-sharing</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>1FDCABCC-3BD2-4504-B4C2-8FAE2DE08E5C</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Ensure Media Sharing Is Disabled</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.macos.cis.media-sharing.payload</string>
+			<key>PayloadType</key>
+			<string>com.apple.preferences.sharing.SharingPrefsExtension</string>
+			<key>PayloadUUID</key>
+			<string>F64ACC56-74C2-47E4-AA14-599826F066B0</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>homeSharingUIStatus</key>
+			<integer>0</integer>
+			<key>legacySharingUIStatus</key>
+			<integer>0</integer>
+			<key>mediaSharingUIStatus</key>
+			<integer>0</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/disable-safari-safefiles.mobileconfig
+++ b/platforms/macos/configuration-profiles/disable-safari-safefiles.mobileconfig
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — disables Safari's "open safe files after download".</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable Safari Safe Files</string>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.safari-safefiles</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>79416917-2B66-4321-A248-266F06E7DF7B</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadContent</key>
+			<dict>
+				<key>com.apple.Safari</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>AutoOpenSafeDownloads</key>
+								<false/>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Ensure Automatic Opening of Safe Files in Safari Is Disabled</string>
+			<key>PayloadDisplayName</key>
+			<string>Custom</string>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.macos.cis.safari-safefiles.payload</string>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadUUID</key>
+			<string>629F3DDB-E042-4603-BA12-E244A4EDCF90</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/enforce-library-validation.mobileconfig
+++ b/platforms/macos/configuration-profiles/enforce-library-validation.mobileconfig
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — enforces Library Validation (blocks unsigned plugin/library injection).</string>
+	<key>PayloadDisplayName</key>
+	<string>Enforce Library Validation</string>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.library-validation</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>5DC43CBB-EA70-41D6-8C9C-627B388CEC8E</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadContent</key>
+			<dict>
+				<key>com.apple.security.libraryvalidation</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>DisableLibraryValidation</key>
+								<false/>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Ensure Library Validation Is Enabled</string>
+			<key>PayloadDisplayName</key>
+			<string>Library Validation</string>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.macos.cis.library-validation.payload</string>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadUUID</key>
+			<string>8F9D3302-9824-4741-BCAB-E2C0DB910635</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/limit-ad-tracking.mobileconfig
+++ b/platforms/macos/configuration-profiles/limit-ad-tracking.mobileconfig
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — limits ad tracking and disables Apple personalized advertising.</string>
+	<key>PayloadDisplayName</key>
+	<string>Limit ad tracking and personalized ads</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.limit-ad-tracking</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>25E88373-F414-43A8-A197-43F1A28E6CF9</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Limit Ad Tracking and Personalized Ads</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.AdLib</string>
+			<key>PayloadType</key>
+			<string>com.apple.AdLib</string>
+			<key>PayloadUUID</key>
+			<string>0150DDB2-ABF8-43F3-BB99-9B179FFE9342</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>allowApplePersonalizedAdvertising</key>
+			<false/>
+			<key>forceLimitAdTracking</key>
+			<true/>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/macos-firewall.mobileconfig
+++ b/platforms/macos/configuration-profiles/macos-firewall.mobileconfig
@@ -40,6 +40,10 @@
         <false/>
         <key>BlockAllIncoming</key>
         <false/>
+        <key>EnableLogging</key>
+        <true/>
+        <key>LoggingOption</key>
+        <string>detail</string>
       </dict>
     </array>
   </dict>

--- a/platforms/macos/configuration-profiles/prevent-autologon.mobileconfig
+++ b/platforms/macos/configuration-profiles/prevent-autologon.mobileconfig
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — prevents automatic login at boot.</string>
+	<key>PayloadDisplayName</key>
+	<string>Prevent automatic login</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.prevent-autologon</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>1490D8EC-F79F-4CDC-99F6-B3FC28EDDF37</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Ensure Automatic Login Is Disabled</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.macos.cis.prevent-autologon.payload</string>
+			<key>PayloadType</key>
+			<string>com.apple.loginwindow</string>
+			<key>PayloadUUID</key>
+			<string>DB06169B-288D-4BF1-9648-7303B0E571B0</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>com.apple.login.mcx.DisableAutoLoginClient</key>
+			<true/>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
+++ b/platforms/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>CIS Benchmark — enables Secure Keyboard Entry in Terminal.app.</string>
+	<key>PayloadDisplayName</key>
+	<string>Secure keyboard entry in Terminal</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.cis.secure-terminal-keyboard</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>5B22FBC1-E0F4-4CC0-9AF6-18A53B6DEFEF</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Secure Keyboard Entry in Terminal</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.Terminal</string>
+			<key>PayloadType</key>
+			<string>com.apple.Terminal</string>
+			<key>PayloadUUID</key>
+			<string>C3A49572-8213-4A41-862B-305C76A6F45A</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>SecureKeyboardEntry</key>
+			<true/>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Adds 10 CIS-aligned macOS configuration profiles adapted from [fleetdm/fleet's it-and-security library](https://github.com/fleetdm/fleet/tree/main/it-and-security/lib/macos/configuration-profiles), with regenerated identifiers per the local profile-authoring rules. Folds firewall logging into the existing [macos-firewall.mobileconfig](platforms/macos/configuration-profiles/macos-firewall.mobileconfig) rather than shipping a second profile that would fight over the `com.apple.security.firewall` payload.

### New profiles
- [disable-bluetooth-file-sharing.mobileconfig](platforms/macos/configuration-profiles/disable-bluetooth-file-sharing.mobileconfig)
- [disable-internet-sharing.mobileconfig](platforms/macos/configuration-profiles/disable-internet-sharing.mobileconfig)
- [disable-media-sharing.mobileconfig](platforms/macos/configuration-profiles/disable-media-sharing.mobileconfig)
- [disable-safari-safefiles.mobileconfig](platforms/macos/configuration-profiles/disable-safari-safefiles.mobileconfig) — no auto-open of "safe" downloads
- [enforce-library-validation.mobileconfig](platforms/macos/configuration-profiles/enforce-library-validation.mobileconfig)
- [prevent-autologon.mobileconfig](platforms/macos/configuration-profiles/prevent-autologon.mobileconfig)
- [limit-ad-tracking.mobileconfig](platforms/macos/configuration-profiles/limit-ad-tracking.mobileconfig)
- [secure-terminal-keyboard.mobileconfig](platforms/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig)
- [date-time.mobileconfig](platforms/macos/configuration-profiles/date-time.mobileconfig) — force automatic time
- [automatic-app-store-updates.mobileconfig](platforms/macos/configuration-profiles/automatic-app-store-updates.mobileconfig)

### Modified
- [macos-firewall.mobileconfig](platforms/macos/configuration-profiles/macos-firewall.mobileconfig) — added `EnableLogging: true` and `LoggingOption: detail` to the existing firewall payload.
- [fleets/workstations.yml](fleets/workstations.yml) — wired all 10 new profiles into `controls.apple_settings.configuration_profiles`, gated on the `macOS hosts` label.

### Notes
- Each profile has both its outer and inner UUIDs regenerated. Outer `PayloadIdentifier`s namespaced under `com.fleetdm.macos.cis.*` (or `com.fleetdm.macos.*` for non-CIS items). Inner `PayloadIdentifier`s that map to a preference domain (`com.apple.AdLib`, `com.apple.Terminal`, `com.apple.applicationaccess`) are preserved as the domain key.
- `PayloadRemovalDisallowed: true` on all of them — users can't strip the profiles locally.

## Test plan
- [x] Flint lint passes
- [x] `fleetctl gitops` apply succeeds and delivers all 11 profiles (10 new + updated firewall) to a workstation
- [x] On a macOS test host: System Settings → Profiles shows all 11; Bluetooth / Internet / Media sharing toggles in System Settings appear locked off; Safari "Open safe files after download" is unchecked and greyed out; Terminal → Secure Keyboard Entry is on
- [x] Verify firewall logging is on: `sudo defaults read /Library/Preferences/com.apple.alf loggingenabled` → `1`
- [x] Verify no regression on existing firewall behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)