### PR TITLE
Add macOS visibility reports to workstations

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -17,6 +17,9 @@ reports:
 - path: ../platforms/macos/reports/get-local-administrator-accounts.reports.yml
 - path: ../platforms/macos/reports/get-builtin-antivirus-status.reports.yml
 - path: ../platforms/macos/reports/get-installed-safari-extensions.reports.yml
+- path: ../platforms/macos/reports/collect-xprotect-reports.reports.yml
+- path: ../platforms/macos/reports/detect-apple-intelligence.reports.yml
+- path: ../platforms/macos/reports/collect-default-browser.reports.yml
 - path: ../platforms/windows/reports/get-antivirus-status.reports.yml
 - path: ../platforms/windows/reports/get-teamviewer-status.reports.yml
 agent_options:

--- a/platforms/macos/reports/collect-default-browser.reports.yml
+++ b/platforms/macos/reports/collect-default-browser.reports.yml
@@ -1,0 +1,21 @@
+- name: Collect default browser on macOS
+  automations_enabled: false
+  description: Collects the default browser setting for local users on macOS hosts.
+  discard_data: false
+  interval: 604800
+  logging: snapshot
+  observer_can_run: true
+  platform: "darwin"
+  query: |
+    SELECT
+      u.username,
+      b.value AS default_browser
+    FROM users u
+    JOIN plist a
+      ON a.path = u.directory || '/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist'
+    JOIN plist b
+      ON b.path = a.path
+      AND b.rowid = a.rowid + 1
+    WHERE a.subkey = 'LSHandlerContentType'
+      AND a.value = 'com.apple.default-app.web-browser'
+      AND b.subkey = 'LSHandlerRoleAll';

--- a/platforms/macos/reports/collect-xprotect-reports.reports.yml
+++ b/platforms/macos/reports/collect-xprotect-reports.reports.yml
@@ -1,0 +1,9 @@
+- name: Collect XProtect reports
+  automations_enabled: false
+  description: Collects XProtect report data from macOS hosts, including malware detection events and remediation actions performed by XProtect.
+  discard_data: false
+  interval: 300
+  logging: snapshot
+  observer_can_run: true
+  platform: "darwin"
+  query: SELECT * FROM xprotect_reports;

--- a/platforms/macos/reports/detect-apple-intelligence.reports.yml
+++ b/platforms/macos/reports/detect-apple-intelligence.reports.yml
@@ -1,0 +1,9 @@
+- name: Detect if Apple Intelligence is enabled
+  automations_enabled: false
+  description: Detects if Apple Intelligence has been enabled.
+  discard_data: false
+  interval: 300
+  logging: snapshot
+  observer_can_run: true
+  platform: "darwin"
+  query: SELECT * FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.CloudSubscriptionFeatures.optIn.plist';


### PR DESCRIPTION
## Summary
Adds three scheduled queries adapted verbatim from [fleetdm/fleet's it-and-security library](https://github.com/fleetdm/fleet/tree/main/it-and-security/lib/macos/reports):

- **[collect-xprotect-reports.reports.yml](platforms/macos/reports/collect-xprotect-reports.reports.yml)** — malware detection and remediation events from Apple's XProtect, via the `xprotect_reports` osquery table. 5-minute interval. Genuine security visibility — surfaces actual malware encounters on the fleet, not just inventory.
- **[detect-apple-intelligence.reports.yml](platforms/macos/reports/detect-apple-intelligence.reports.yml)** — per-user opt-in state of Apple Intelligence (`com.apple.CloudSubscriptionFeatures.optIn.plist`). 5-minute interval. Useful for tracking AI-feature rollout posture.
- **[collect-default-browser.reports.yml](platforms/macos/reports/collect-default-browser.reports.yml)** — default browser per local user, via the `LaunchServices` secure plist. Weekly interval.

All three are darwin-only and wired into [fleets/workstations.yml](fleets/workstations.yml) alongside the other macOS reports.

## Test plan
- [x] Flint lint passes
- [x] `fleetctl gitops` apply succeeds and the three new queries appear in Fleet under the Workstations team
- [x] After a refetch on a macOS test host, each query returns rows (or returns an empty set without errors, where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)