### PR TITLE
Run lint workflow only on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: 'Lint Fleet GitOps configuration'
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- Removes the `push: branches: [main]` trigger from `.github/workflows/lint.yml`.
- Flint now runs only on `pull_request` (the pre-merge gate) and `workflow_dispatch` (manual runs).
- Avoids redundant post-merge runs — the same lint already ran on the PR.

## Test plan

- [ ] Open this PR and confirm the lint workflow runs against it
- [ ] After merge, confirm no lint workflow run is triggered on the resulting commit to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)