### PR TITLE
Clarify which collection directories auto-load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,14 @@
 
 - **YAML files under `labels/`, `platforms/*/policies/`, and `platforms/*/reports/` are bare top-level lists — no `labels:` / `policies:` / `reports:` wrapper key at the top of the file.** Each entry is a single resource object (label, policy, or report). Wrapping the list in a key will cause `fleetctl gitops` to reject the file.
 
-- **`labels/` is the only collection directory that auto-loads. Everything under `platforms/*/` must be wired into each `fleets/*.yml` that should receive it.** `default.yml` globs `labels/` via `labels: - paths: ./labels/*.yml`, so dropping a new file into `labels/` is enough to deploy it. Every other resource type is opted in fleet-by-fleet through an explicit `path:` (or `paths:` glob) entry:
+- **A few collection directories auto-load via `paths:` globs; everything else under `platforms/*/` must be wired into each `fleets/*.yml` that should receive it with an explicit `path:`.** The auto-loading globs in this repo today are:
+  - `labels/*.yml` → globbed by `default.yml` (`labels: - paths: ./labels/*.yml`). Labels are global, so a new file in `labels/` is live repo-wide on next apply.
+  - `platforms/macos/configuration-profiles/all-macos/*.mobileconfig` → globbed by `fleets/workstations.yml` under `controls.apple_settings.configuration_profiles:`. Drop a `.mobileconfig` into `all-macos/` and every workstation gets it.
+  - `platforms/macos/declaration-profiles/all-macos/*.json` → globbed by `fleets/workstations.yml` under the same key. Same behavior for DDM declarations.
+
+  These globs are *scoped to the file that declares them* — the `all-macos/` globs only fire into `workstations`, not into `servers` or `mobile-devices`. To auto-load a directory into a different fleet, add the `paths:` glob to that fleet's YAML too.
+
+  Every other resource type is opted in fleet-by-fleet through an explicit `path:` (or a new `paths:` glob) entry:
   - **Policies** → under `policies:` (e.g. `- path: ../platforms/macos/policies/macos-device-health.policies.yml`)
   - **Reports** → under `reports:`
   - **Apple configuration profiles & DDM declarations** — macOS, iOS, and iPadOS share a *single* list; Fleet routes by file contents → `controls.apple_settings.configuration_profiles:`. Declarations that apply to multiple Apple platforms are conventionally staged under `platforms/all/declaration-profiles/` so they can be referenced from any fleet (e.g. [platforms/all/declaration-profiles/disable-beta-updates-ddm.json](platforms/all/declaration-profiles/disable-beta-updates-ddm.json)).
@@ -25,7 +32,7 @@
   - **Agent options** → `agent_options.path:` (typically `../platforms/agent-options.yml`)
   - **Apple Automated Device Enrollment (ADE/DEP) profiles** (`.json` staged under `platforms/macos/enrollment-profiles/`) → per-fleet `setup_experience.apple_setup_assistant:` path. Applies to macOS and iOS/iPadOS hosts enrolling via Apple Business Manager. Other `setup_experience` keys (`bootstrap_package`, `script`, `enable_end_user_authentication`, `lock_end_user_info`, `apple_enable_release_device_manually`) live alongside it in the same per-fleet block — see Fleet's GitOps YAML reference for the full shape.
 
-  A new file added under `platforms/*/` with no fleet wiring is silent: it sits in the repo, but no host ever receives it. When introducing a resource, decide which fleets it applies to and add the `path:` entry in each one.
+  A new file added under `platforms/*/` *outside an auto-loading glob directory* with no fleet wiring is silent: it sits in the repo, but no host ever receives it. When introducing a resource, decide which fleets it applies to — if it belongs in an `all-macos/` glob directory, drop it there and you're done for the fleets that glob it; otherwise add an explicit `path:` entry to each fleet that should receive it.
 
 - **When duplicating an existing `.mobileconfig` or DDM `.json` as a starting point for a new profile/declaration, regenerate its identifiers before editing further:**
   - `.mobileconfig`: regenerate the top-level `PayloadIdentifier` and `PayloadUUID`, and every per-payload `PayloadIdentifier` / `PayloadUUID` inside `PayloadContent`.


### PR DESCRIPTION
## Summary
- Correct the CLAUDE.md claim that `labels/` is the only auto-loading collection directory — the `all-macos/` globs under macOS configuration- and declaration-profiles also auto-load (into `fleets/workstations.yml`)
- Note that `paths:` globs are scoped to the file that declares them, so the `all-macos/` directories only fire into workstations today

## Test plan
- [x] Docs-only change; no CI behavior impact