### PR TITLE
Assign ABM hosts to fleets by platform

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -33,6 +33,10 @@ org_settings:
     zendesk:
   mdm:
     apple_business_manager:
+    - organization_name: Fleet Device Management Inc.
+      macos_fleet: Workstations
+      ios_fleet: Mobile Devices
+      ipados_fleet: Mobile Devices
     apple_server_url:
     end_user_authentication:
       entity_id:


### PR DESCRIPTION
## Summary

Configure `org_settings.mdm.apple_business_manager` in `default.yml` so Apple Business Manager hosts auto-assign to the right fleet by platform when they appear in ABM:

- **macOS** → Workstations
- **iOS** → Mobile Devices
- **iPadOS** → Mobile Devices

## Notes

- `organization_name` (`Fleet Device Management Inc.`) must match the ABM org name exactly, and the fleet values must match each fleet's `name:` field — they do, per `fleets/workstations.yml` and `fleets/mobile-devices.yml`.
- Takes effect on the next `fleetctl gitops` run. Only newly-appearing ABM hosts auto-assign; already-enrolled devices aren't retroactively moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)