### PR TITLE
Enforce latest Apple OS versions with 5-day window

### DIFF
--- a/fleets/mobile-devices.yml
+++ b/fleets/mobile-devices.yml
@@ -15,10 +15,10 @@ agent_options:
 controls:
   enable_disk_encryption: true
   ios_updates:
-    deadline: "2026-05-20"
+    deadline: "2026-06-19"
     minimum_version: "26.5"
   ipados_updates:
-    deadline: "2026-05-20"
+    deadline: "2026-06-19"
     minimum_version: "26.5"
   apple_settings:
     configuration_profiles:

--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -30,8 +30,8 @@ controls:
   enable_disk_encryption: true
   enable_recovery_lock_password: true
   macos_updates:
-    deadline: '2026-05-20'
-    minimum_version: '26.5'
+    deadline: '2026-06-19'
+    minimum_version: '26.5.1'
   apple_settings:
     configuration_profiles:
     - paths: ../platforms/macos/declaration-profiles/all-macos/*.json


### PR DESCRIPTION
## Summary

Refresh OS update enforcement for Apple hosts in the **Workstations** and **Mobile Devices** fleets. The previous values were stale — the deadline (`2026-05-20`) had already passed. Updated to the current latest releases with a deadline 5 days out (`2026-06-19`):

| Platform | Fleet | minimum_version |
|----------|-------|-----------------|
| macOS | Workstations | `26.5.1` |
| iOS | Mobile Devices | `26.5` |
| iPadOS | Mobile Devices | `26.5` |

## Version choices

- **macOS 26.5.1** — point release from June 1, 2026; applies to all macOS 26-capable Macs.
- **iOS 26.5** — iOS 26.5.1 shipped June 1 but only for the iPhone 17 series / iPhone Air. `26.5` (May 11) is the latest version *every* supported iPhone can install; iPhone 17s already on 26.5.1 still satisfy the minimum.
- **iPadOS 26.5** — latest iPadOS 26 release (May 11, 2026).

## Notes

- The `deadline` is an absolute date, not a rolling window. If this merges later than today, bump it so hosts still get a full 5 days.
- These minimums will need bumping when macOS 27 / iOS 27 ship (~Sept 2026), or sooner as 26.5.1 rolls out to all iPhones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)