### PR TITLE
Exclude nobody user from SecureToken status report

### DIFF
--- a/platforms/macos/reports/get-securetoken-status.reports.yml
+++ b/platforms/macos/reports/get-securetoken-status.reports.yml
@@ -7,7 +7,8 @@
       CASE WHEN fu.uuid IS NOT NULL THEN 1 ELSE 0 END AS has_secure_token
     FROM users u
     LEFT JOIN filevault_users fu ON fu.uuid = u.uuid
-    WHERE u.uid >= 501;
+    WHERE u.uid >= 501
+      AND u.username != 'nobody';
   interval: 21600 # 6 hours
   observer_can_run: true
   automations_enabled: true


### PR DESCRIPTION
## Summary
The SecureToken status report was surfacing the `nobody` pseudo-account (uid `4294967294`), which slips past the `uid >= 501` filter and adds a noise row per host.

## Change
Add `AND u.username != 'nobody'` to the `WHERE` clause so only real local accounts are reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)