### PR TITLE
Add Thunderbolt bus speed report to Workstations

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -23,6 +23,7 @@ reports:
 - path: ../platforms/macos/reports/collect-xprotect-reports.reports.yml
 - path: ../platforms/macos/reports/detect-apple-intelligence.reports.yml
 - path: ../platforms/macos/reports/collect-default-browser.reports.yml
+- path: ../platforms/macos/reports/get-thunderbolt-bus-speed.reports.yml
 - path: ../platforms/windows/reports/get-antivirus-status.reports.yml
 - path: ../platforms/windows/reports/get-teamviewer-status.reports.yml
 agent_options:

--- a/platforms/macos/reports/get-thunderbolt-bus-speed.reports.yml
+++ b/platforms/macos/reports/get-thunderbolt-bus-speed.reports.yml
@@ -1,0 +1,13 @@
+- name: Get Thunderbolt bus speed on macOS
+  description: Reports each Thunderbolt bus on the host along with the current link speed of its first receptacle, parsed from system_profiler's SPThunderboltDataType. Useful for auditing Thunderbolt/USB-C port negotiation and spotting busses negotiating below their rated speed.
+  query: |
+    SELECT
+      json_extract(je.value, '$._name') AS bus_name,
+      json_extract(je.value, '$.receptacle_1_tag.current_speed_key') AS current_speed
+    FROM system_profiler AS sp,
+      json_each(sp.value) AS je
+    WHERE sp.data_type = 'SPThunderboltDataType';
+  interval: 604800 # 7 days
+  observer_can_run: true
+  automations_enabled: false
+  platform: darwin


### PR DESCRIPTION
## Summary
Adds a macOS report that captures each Thunderbolt bus and its first receptacle's current link speed, parsed from `system_profiler`'s `SPThunderboltDataType`. Useful for auditing Thunderbolt/USB-C port negotiation and spotting busses negotiating below their rated speed.

## Changes
- New report: `platforms/macos/reports/get-thunderbolt-bus-speed.reports.yml` (`platform: darwin`, 7-day interval, automations off)
- Wired into `fleets/workstations.yml` under `reports:` (reports require an explicit `path:` per fleet — they don't auto-load)

## Notes
- The query reads only `receptacle_1_tag`, so a bus with differently-keyed or multiple receptacles reports `NULL`/only the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)