### PR TITLE
Point ABM default fleets at Testing

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -34,9 +34,9 @@ org_settings:
   mdm:
     apple_business_manager:
     - organization_name: Fleet Device Management Inc.
-      macos_fleet: Workstations
-      ios_fleet: Mobile Devices
-      ipados_fleet: Mobile Devices
+      macos_fleet: Testing
+      ios_fleet: Testing
+      ipados_fleet: Testing
     apple_server_url:
     end_user_authentication:
       entity_id:


### PR DESCRIPTION
## Summary

Change the Apple Business Manager default fleet for macOS, iOS, and iPadOS enrollments from Workstations/Mobile Devices to **Testing** in `default.yml` (`org_settings.mdm.apple_business_manager`).

```yaml
apple_business_manager:
- organization_name: Fleet Device Management Inc.
  macos_fleet: Testing
  ios_fleet: Testing
  ipados_fleet: Testing
```

## Impact

- Newly-enrolling / re-enrolling ADE (ABM/DEP) devices for all three Apple platforms land in the **Testing** fleet.
- Already-enrolled hosts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)