### PR TITLE
Bump Apple OS update targets to 26.5.2, deadline 2026-07-07

### DIFF
--- a/fleets/mobile-devices.yml
+++ b/fleets/mobile-devices.yml
@@ -15,11 +15,11 @@ agent_options:
 controls:
   enable_disk_encryption: true
   ios_updates:
-    deadline: "2026-06-19"
-    minimum_version: "26.5"
+    deadline: "2026-07-07"
+    minimum_version: "26.5.2"
   ipados_updates:
-    deadline: "2026-06-19"
-    minimum_version: "26.5"
+    deadline: "2026-07-07"
+    minimum_version: "26.5.2"
   apple_settings:
     configuration_profiles:
     - path: ../platforms/all/declaration-profiles/disable-beta-updates-ddm.json

--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -32,8 +32,8 @@ controls:
   enable_disk_encryption: true
   enable_recovery_lock_password: true
   macos_updates:
-    deadline: '2026-06-19'
-    minimum_version: '26.5.1'
+    deadline: '2026-07-07'
+    minimum_version: '26.5.2'
   apple_settings:
     configuration_profiles:
     - paths: ../platforms/macos/declaration-profiles/all-macos/*.json


### PR DESCRIPTION
## Summary
- Set `macos_updates.minimum_version` to `26.5.2` (latest released macOS Tahoe) in `fleets/workstations.yml`
- Set `ios_updates.minimum_version` and `ipados_updates.minimum_version` to `26.5.2` in `fleets/mobile-devices.yml`
- Deadline set to `2026-07-07` (one week out) for all three controls

## Test plan
- [ ] `fleetctl gitops` dry-run / CI validation passes
- [ ] Confirm workstations and mobile-devices hosts show the new OS update requirement in Fleet after apply