### PR TITLE
Allow beta OS updates on the Testing fleet

### DIFF
--- a/fleets/testing.yml
+++ b/fleets/testing.yml
@@ -5,6 +5,9 @@ reports:
 agent_options:
   path: ../platforms/agent-options.yml
 controls:
+  apple_settings:
+    configuration_profiles:
+    - path: ../platforms/macos/declaration-profiles/allow-beta-updates-ddm.json
 settings:
   secrets:
   - secret: $FLEET_TESTING_ENROLL_SECRET

--- a/platforms/macos/declaration-profiles/allow-beta-updates-ddm.json
+++ b/platforms/macos/declaration-profiles/allow-beta-updates-ddm.json
@@ -1,0 +1,9 @@
+{
+    "Type": "com.apple.configuration.softwareupdate.settings",
+    "Identifier": "267392e0-2713-45ca-95a0-c08e69015388",
+    "Payload": {
+        "Beta": {
+            "ProgramEnrollment": "Allowed"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `com.apple.configuration.softwareupdate.settings` DDM declaration with `Beta.ProgramEnrollment: Allowed`, actively granting Testing hosts the ability to opt into beta updates (rather than leaving the setting unmanaged).
- Wires the declaration into `fleets/testing.yml` under `controls.apple_settings.configuration_profiles`.

Testing previously had no `apple_settings.configuration_profiles` at all, so hosts moved into that fleet from Workstations or Servers could be left with a stale `AlwaysOff` beta-enrollment declaration until it cleared on its own. This declaration explicitly overrides that.

Requires macOS 15.4+ (supervised) per Apple's DDM schema for this declaration type.

## Test plan
- [ ] `fleetctl gitops --dry-run` passes in CI
- [ ] After merge/apply, confirm a Testing-fleet Mac shows the beta-updates declaration in Fleet's host details → OS settings as verified
- [ ] Confirm Beta Updates toggle in System Settings is user-controllable (not greyed out as `AlwaysOff`) on a Testing host

🤖 Generated with [Claude Code](https://claude.com/claude-code)