### PR TITLE
Enforce supervision and non-removable MDM for ADE-enrolled Macs

### DIFF
--- a/fleets/testing.yml
+++ b/fleets/testing.yml
@@ -8,6 +8,8 @@ controls:
   apple_settings:
     configuration_profiles:
     - path: ../platforms/macos/declaration-profiles/allow-beta-updates-ddm.json
+  setup_experience:
+    apple_setup_assistant: ../platforms/macos/enrollment-profiles/automatic-enrollment.dep.json
 settings:
   secrets:
   - secret: $FLEET_TESTING_ENROLL_SECRET

--- a/platforms/macos/enrollment-profiles/automatic-enrollment.dep.json
+++ b/platforms/macos/enrollment-profiles/automatic-enrollment.dep.json
@@ -1,7 +1,8 @@
 {
 	"profile_name": "Fleet's example automatic enrollment profile",
 	"allow_pairing": true,
-	"is_mdm_removable": true,
+	"is_mdm_removable": false,
+	"is_supervised": true,
 	"org_magic": "1",
 	"language": "en",
 	"region": "US",


### PR DESCRIPTION
## Summary
- `platforms/macos/enrollment-profiles/automatic-enrollment.dep.json`: sets `is_mdm_removable: false` and adds `is_supervised: true`. Per Apple's DEP Profile schema, `is_mdm_removable` can only be `false` when `is_supervised` is explicitly `true`.
- `fleets/testing.yml`: wires the profile in via `controls.setup_experience.apple_setup_assistant`. It was previously unreferenced by any fleet, so it was never actually delivered to any host.

Wired into **Testing** specifically because `default.yml`'s `org_settings.mdm.apple_business_manager` sets `macos_fleet: Testing` — that's the team all ADE-enrolled Macs land in today. Note this only affects the initial out-of-box Setup Assistant flow; Macs later transferred to other teams won't retroactively pick this up since Setup Assistant only runs once.

## Test plan
- [ ] `fleetctl gitops --dry-run` passes in CI
- [ ] ADE-enroll a test Mac and confirm at Setup Assistant it lands supervised
- [ ] Confirm in Fleet's host details (or `sudo profiles status -type enrollment`) that the MDM profile shows as non-removable

🤖 Generated with [Claude Code](https://claude.com/claude-code)