### PR TITLE
Add macOS policy for pending Apple software updates

### DIFF
--- a/platforms/macos/policies/macos-device-health.policies.yml
+++ b/platforms/macos/policies/macos-device-health.policies.yml
@@ -52,6 +52,13 @@
         AND name = 'GuestEnabled' AND CAST(value AS INT) = 0
     );
 
+- name: macOS - All available Apple software updates installed
+  platform: darwin
+  description: |
+    Checks that no Apple Software Update items are pending on the host. Covers minor/security updates and non-OS updates (e.g. Safari) that macos_updates enforcement of minimum_version does not address, since that setting only targets the OS version itself.
+  resolution: As an end user, open System Settings > General > Software Update and install any available updates, or run `softwareupdate --install --all` from Terminal.
+  query: SELECT 1 FROM software_update WHERE software_update_required = 0;
+
 - name: macOS - Software Update settings DDM declaration active
   platform: darwin
   description: |


### PR DESCRIPTION
## Summary
- Adds a "macOS - All available Apple software updates installed" policy to `platforms/macos/policies/macos-device-health.policies.yml`, wired into the Workstations fleet via existing file reference.
- Uses Fleet's `software_update` osquery table (`software_update_required = 0`) to flag hosts with pending Apple Software Update items — covering minor/security and non-OS updates (e.g. Safari) that `macos_updates.minimum_version` enforcement doesn't reach, since that setting only targets the OS version itself.

## Test plan
- [x] `fleetctl gitops` dry-run / lint passes
- [x] Policy shows up under Workstations team in Fleet UI after apply
- [ ] Verify pass/fail behavior on a host with pending updates via `softwareupdate --list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)