### PR TITLE
Enforce Gatekeeper on the Testing fleet

### DIFF
--- a/fleets/testing.yml
+++ b/fleets/testing.yml
@@ -1,5 +1,6 @@
 name: Testing
 policies:
+- path: ../platforms/macos/policies/macos-gatekeeper.policies.yml
 reports:
 agent_options:
   path: ../platforms/agent-options.yml
@@ -7,6 +8,7 @@ controls:
   apple_settings:
     configuration_profiles:
     - path: ../platforms/macos/declaration-profiles/allow-beta-updates-ddm.json
+    - path: ../platforms/macos/configuration-profiles/enforce-gatekeeper.mobileconfig
   setup_experience:
     apple_setup_assistant: ../platforms/macos/enrollment-profiles/automatic-enrollment.dep.json
 settings:

--- a/platforms/macos/configuration-profiles/enforce-gatekeeper.mobileconfig
+++ b/platforms/macos/configuration-profiles/enforce-gatekeeper.mobileconfig
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>Enforces Gatekeeper (blocks unsigned/unnotarized apps; allows App Store and identified-developer apps).</string>
+	<key>PayloadDisplayName</key>
+	<string>Enforce Gatekeeper</string>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.macos.testing.enforce-gatekeeper</string>
+	<key>PayloadOrganization</key>
+	<string>Kitzy.net</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>91E94369-E08F-491F-AE38-BBFA3838F023</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>AllowIdentifiedDevelopers</key>
+			<true/>
+			<key>EnableAssessment</key>
+			<true/>
+			<key>PayloadDescription</key>
+			<string>Enable Gatekeeper assessment (App Store and identified developers)</string>
+			<key>PayloadDisplayName</key>
+			<string>Gatekeeper</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.macos.testing.enforce-gatekeeper.payload</string>
+			<key>PayloadType</key>
+			<string>com.apple.systempolicy.control</string>
+			<key>PayloadUUID</key>
+			<string>1D2EF4E3-4004-4BAB-A305-2DAEB51B520D</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/platforms/macos/policies/macos-gatekeeper.policies.yml
+++ b/platforms/macos/policies/macos-gatekeeper.policies.yml
@@ -1,0 +1,5 @@
+- name: macOS - Gatekeeper enabled
+  platform: darwin
+  description: Checks that Gatekeeper is enabled, blocking unsigned/unnotarized apps from running.
+  resolution: As an IT admin, deploy the Enforce Gatekeeper profile (platforms/macos/configuration-profiles/enforce-gatekeeper.mobileconfig) and confirm it shows as verified in the host's MDM panel.
+  query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.systempolicy.control' AND username = '' AND name = 'EnableAssessment' AND CAST(value AS INT) = 1;


### PR DESCRIPTION
## Summary
- Adds `platforms/macos/configuration-profiles/enforce-gatekeeper.mobileconfig`, a `com.apple.systempolicy.control` profile enabling Gatekeeper (`EnableAssessment=true`, `AllowIdentifiedDevelopers=true`) to block unsigned/unnotarized apps
- Adds `platforms/macos/policies/macos-gatekeeper.policies.yml` to verify enforcement via `managed_policies` (legacy `.mobileconfig` profiles don't populate DDM state)
- Wires both into `fleets/testing.yml` only — scoped to the Testing fleet, not Workstations

## Test plan
- [ ] `fleetctl gitops` dry-run / CI validation passes
- [ ] Profile delivers and shows Verified in the Testing fleet's MDM panel
- [ ] Confirm unsigned app is blocked on a Testing host
- [ ] "macOS - Gatekeeper enabled" policy passes on a host with the profile applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)