### PR TITLE
Enforce Apple OS 26.6 with a 3-day deadline

### DIFF
--- a/fleets/mobile-devices.yml
+++ b/fleets/mobile-devices.yml
@@ -15,11 +15,11 @@ agent_options:
 controls:
   enable_disk_encryption: true
   ios_updates:
-    deadline: "2026-07-07"
-    minimum_version: "26.5.2"
+    deadline: "2026-07-31"
+    minimum_version: "26.6"
   ipados_updates:
-    deadline: "2026-07-07"
-    minimum_version: "26.5.2"
+    deadline: "2026-07-31"
+    minimum_version: "26.6"
   apple_settings:
     configuration_profiles:
     - path: ../platforms/all/declaration-profiles/disable-beta-updates-ddm.json

--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -32,8 +32,8 @@ controls:
   enable_disk_encryption: true
   enable_recovery_lock_password: true
   macos_updates:
-    deadline: '2026-07-07'
-    minimum_version: '26.5.2'
+    deadline: '2026-07-31'
+    minimum_version: '26.6'
   apple_settings:
     configuration_profiles:
     - paths: ../platforms/macos/declaration-profiles/all-macos/*.json


### PR DESCRIPTION
## Summary

macOS Tahoe 26.6, iOS 26.6, and iPadOS 26.6 shipped on 2026-07-27. This bumps the OS update floor to `26.6` for the fleets that already enforce OS updates, with a deadline of **2026-07-31** (3 days out).

| Fleet | Key | Was | Now |
|---|---|---|---|
| Workstations | `macos_updates` | 26.5.2 / 2026-07-07 | **26.6 / 2026-07-31** |
| Mobile Devices | `ios_updates` | 26.5.2 / 2026-07-07 | **26.6 / 2026-07-31** |
| Mobile Devices | `ipados_updates` | 26.5.2 / 2026-07-07 | **26.6 / 2026-07-31** |

Covers 3 Macs (Workstations) and 1 iPhone (Deimos).

## Out of scope

The Apple hosts in **Servers** (Nova, macOS) and **Testing** (Mac mini + iPad) have no `*_updates` block today and are intentionally left that way — Servers runs services that a forced 3-day restart would interrupt, and Testing is the beta fleet.

## Notes

- `26.6` is the correct version string — Apple reports Tahoe 26.6 as `26.6` (build 25G72), and Fleet's semver comparison treats it as a floor, so later releases (26.6.1, 27.x) satisfy it without another edit.
- Fleet starts the nudge countdown when a host **first sees** the new setting, not from the date in the YAML. Hosts currently offline (Laurie's MacBook Air, MacBook Air, Deimos) won't begin their cycle until they check in — with a 3-day deadline, a host checking in on the 31st gets forced to restart nearly immediately rather than getting a graduated warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)