### PR TITLE
Add FMAs and patch policies for apps found on Workstations hosts

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -60,10 +60,16 @@ software:
   - slug: 1password/darwin
     setup_experience: false
     self_service: true
+  - slug: adobe-acrobat-reader/darwin
+    setup_experience: false
+    self_service: true
   - slug: balenaetcher/darwin
     setup_experience: false
     self_service: true
   - slug: canva/darwin
+    setup_experience: false
+    self_service: true
+  - slug: chatgpt/darwin
     setup_experience: false
     self_service: true
   - slug: claude/darwin
@@ -72,10 +78,19 @@ software:
   - slug: cleanshot/darwin
     setup_experience: false
     self_service: true
+  - slug: cursor/darwin
+    setup_experience: false
+    self_service: true
   - slug: discord/darwin
     setup_experience: false
     self_service: true
+  - slug: displaylink/darwin
+    setup_experience: false
+    self_service: true
   - slug: docker-desktop/darwin
+    setup_experience: false
+    self_service: true
+  - slug: dymo-connect/darwin
     setup_experience: false
     self_service: true
   - slug: elgato-control-center/darwin
@@ -102,6 +117,12 @@ software:
   - slug: gpg-suite/darwin
     setup_experience: false
     self_service: true
+  - slug: handbrake-app/darwin
+    setup_experience: false
+    self_service: true
+  - slug: imazing-converter/darwin
+    setup_experience: false
+    self_service: true
   - slug: imazing-profile-editor/darwin
     setup_experience: false
     self_service: true
@@ -109,6 +130,12 @@ software:
     setup_experience: false
     self_service: true
   - slug: logi-options+/darwin
+    setup_experience: false
+    self_service: true
+  - slug: meetingbar/darwin
+    setup_experience: false
+    self_service: true
+  - slug: microsoft-teams/darwin
     setup_experience: false
     self_service: true
   - slug: visual-studio-code/darwin
@@ -132,6 +159,12 @@ software:
   - slug: slack/darwin
     setup_experience: false
     self_service: true
+  - slug: spotify/darwin
+    setup_experience: false
+    self_service: true
+  - slug: steam/darwin
+    setup_experience: false
+    self_service: true
   - slug: sublime-text/darwin
     setup_experience: false
     self_service: true
@@ -142,6 +175,9 @@ software:
     setup_experience: false
     self_service: true
   - slug: textexpander/darwin
+    setup_experience: false
+    self_service: true
+  - slug: the-unarchiver/darwin
     setup_experience: false
     self_service: true
   - slug: transmit/darwin

--- a/platforms/macos/policies/macos-fma-patch.policies.yml
+++ b/platforms/macos/policies/macos-fma-patch.policies.yml
@@ -2,6 +2,10 @@
   type: patch
   fleet_maintained_app_slug: 1password/darwin
   install_software: true
+- name: Adobe Acrobat Reader up to date
+  type: patch
+  fleet_maintained_app_slug: adobe-acrobat-reader/darwin
+  install_software: true
 - name: balenaEtcher up to date
   type: patch
   fleet_maintained_app_slug: balenaetcher/darwin
@@ -9,6 +13,10 @@
 - name: Canva up to date
   type: patch
   fleet_maintained_app_slug: canva/darwin
+  install_software: true
+- name: ChatGPT up to date
+  type: patch
+  fleet_maintained_app_slug: chatgpt/darwin
   install_software: true
 - name: Claude up to date
   type: patch
@@ -18,13 +26,25 @@
   type: patch
   fleet_maintained_app_slug: cleanshot/darwin
   install_software: true
+- name: Cursor up to date
+  type: patch
+  fleet_maintained_app_slug: cursor/darwin
+  install_software: true
 - name: Discord up to date
   type: patch
   fleet_maintained_app_slug: discord/darwin
   install_software: true
+- name: DisplayLink up to date
+  type: patch
+  fleet_maintained_app_slug: displaylink/darwin
+  install_software: true
 - name: Docker Desktop up to date
   type: patch
   fleet_maintained_app_slug: docker-desktop/darwin
+  install_software: true
+- name: DYMO Connect up to date
+  type: patch
+  fleet_maintained_app_slug: dymo-connect/darwin
   install_software: true
 - name: Elgato Control Center up to date
   type: patch
@@ -58,6 +78,14 @@
   type: patch
   fleet_maintained_app_slug: gpg-suite/darwin
   install_software: true
+- name: HandBrake up to date
+  type: patch
+  fleet_maintained_app_slug: handbrake-app/darwin
+  install_software: true
+- name: iMazing Converter up to date
+  type: patch
+  fleet_maintained_app_slug: imazing-converter/darwin
+  install_software: true
 - name: iMazing Profile Editor up to date
   type: patch
   fleet_maintained_app_slug: imazing-profile-editor/darwin
@@ -69,6 +97,14 @@
 - name: Logi Options+ up to date
   type: patch
   fleet_maintained_app_slug: logi-options+/darwin
+  install_software: true
+- name: MeetingBar up to date
+  type: patch
+  fleet_maintained_app_slug: meetingbar/darwin
+  install_software: true
+- name: Microsoft Teams up to date
+  type: patch
+  fleet_maintained_app_slug: microsoft-teams/darwin
   install_software: true
 - name: Visual Studio Code up to date
   type: patch
@@ -98,6 +134,14 @@
   type: patch
   fleet_maintained_app_slug: slack/darwin
   install_software: true
+- name: Spotify up to date
+  type: patch
+  fleet_maintained_app_slug: spotify/darwin
+  install_software: true
+- name: Steam up to date
+  type: patch
+  fleet_maintained_app_slug: steam/darwin
+  install_software: true
 - name: Sublime Text up to date
   type: patch
   fleet_maintained_app_slug: sublime-text/darwin
@@ -113,6 +157,10 @@
 - name: TextExpander up to date
   type: patch
   fleet_maintained_app_slug: textexpander/darwin
+  install_software: true
+- name: The Unarchiver up to date
+  type: patch
+  fleet_maintained_app_slug: the-unarchiver/darwin
   install_software: true
 - name: Transmit up to date
   type: patch


### PR DESCRIPTION
## Summary

A complete software inventory of the 3 macOS Workstations hosts (pulled via the paginated Fleet REST API — the MCP `get_software` tool silently truncates at 200 rows) found **98 top-level `/Applications` apps**. Matching them against the Fleet-maintained app catalog by bundle identifier surfaced **12 apps installed on devices with an FMA available but not yet managed** in this repo.

## Changes

Adds an FMA entry (`self_service: true`, `setup_experience: false`) and a matching `type: patch` policy (`install_software: true`) for each, following existing conventions:

| App | Installed on | Slug |
|---|---|---|
| Adobe Acrobat Reader | hosts 10, 23 | `adobe-acrobat-reader/darwin` |
| ChatGPT Desktop | hosts 10, 23 | `chatgpt/darwin` |
| Cursor | host 11 | `cursor/darwin` |
| DisplayLink | host 11 | `displaylink/darwin` |
| DYMO Connect | host 11 | `dymo-connect/darwin` |
| HandBrake | host 11 | `handbrake-app/darwin` |
| iMazing Converter | hosts 10, 23 | `imazing-converter/darwin` |
| MeetingBar | host 11 | `meetingbar/darwin` |
| Microsoft Teams | hosts 10, 23 | `microsoft-teams/darwin` |
| Spotify | all 3 hosts | `spotify/darwin` |
| Steam | host 11 | `steam/darwin` |
| The Unarchiver | host 11 | `the-unarchiver/darwin` |

All slugs verified against the canonical FMA catalog (`ee/maintained-apps/outputs/apps.json` in fleetdm/fleet). After this change: 47 FMA entries ↔ 47 patch policies, one-to-one.

## Heads up

- **Acrobat Reader 11.0.23** (2017-era) and **Microsoft Teams classic 1.00** on hosts 10/23 will be force-upgraded to current versions by their patch policies — correct security-wise, but a visible change for those users.
- 39 third-party apps on devices have **no FMA available** (Dante suite, Allen & Heath/Behringer editors, iLok, Shure WWB, App Store apps like WireGuard/Pixelmator Pro). Notably stale: **Skype 8.60**, **join.me**, **TurboTax 2013**, **iPhoto 9.6.1** — removal candidates rather than management targets; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)