### PR TITLE
Temporarily remove the Steam FMA to refresh its patch policy query

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -161,9 +161,6 @@ software:
   - slug: spotify/darwin
     setup_experience: false
     self_service: true
-  - slug: steam/darwin
-    setup_experience: false
-    self_service: true
   - slug: sublime-text/darwin
     setup_experience: false
     self_service: true

--- a/platforms/macos/policies/macos-fma-patch.policies.yml
+++ b/platforms/macos/policies/macos-fma-patch.policies.yml
@@ -138,10 +138,6 @@
   type: patch
   fleet_maintained_app_slug: spotify/darwin
   install_software: true
-- name: Steam up to date
-  type: patch
-  fleet_maintained_app_slug: steam/darwin
-  install_software: true
 - name: Sublime Text up to date
   type: patch
   fleet_maintained_app_slug: sublime-text/darwin


### PR DESCRIPTION
Step 1 of 2. Paired with a follow-up PR that restores both entries.

[fleetdm/fleet#50428](https://github.com/fleetdm/fleet/pull/50428) fixed the generated `steam/darwin` patch query to compare `bundle_version` instead of the always-empty `bundle_short_version` ([fleetdm/fleet#50408](https://github.com/fleetdm/fleet/issues/50408)). The fixed manifest is already live on the FMA CDN:

```
SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.valvesoftware.steam' AND version_compare(bundle_version, '6.0') < 0);
```

Steam's cask version is unchanged (still `6.0`), so a plain GitOps re-apply won't pick it up — Fleet generates the patch policy from `software_installers.patch_query` on the team's existing installer row, which was hydrated from the old manifest. Removing and re-adding the app forces a fresh hydrate.

Removing the app does **not** uninstall Steam from hosts. It does drop the policy's pass/fail history, which is currently 100% failing anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)