### PR TITLE
Re-add the Steam FMA to pick up the fixed patch policy query

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -161,6 +161,9 @@ software:
   - slug: spotify/darwin
     setup_experience: false
     self_service: true
+  - slug: steam/darwin
+    setup_experience: false
+    self_service: true
   - slug: sublime-text/darwin
     setup_experience: false
     self_service: true

--- a/platforms/macos/policies/macos-fma-patch.policies.yml
+++ b/platforms/macos/policies/macos-fma-patch.policies.yml
@@ -138,6 +138,10 @@
   type: patch
   fleet_maintained_app_slug: spotify/darwin
   install_software: true
+- name: Steam up to date
+  type: patch
+  fleet_maintained_app_slug: steam/darwin
+  install_software: true
 - name: Sublime Text up to date
   type: patch
   fleet_maintained_app_slug: sublime-text/darwin


### PR DESCRIPTION
Step 2 of 2, following #207. Reverts the temporary removal exactly — same `setup_experience: false` / `self_service: true`, same policy with `install_software: true`.

Re-adding forces Fleet to re-hydrate the workstations installer from the current FMA manifest, so `software_installers.patch_query` picks up the fix from [fleetdm/fleet#50428](https://github.com/fleetdm/fleet/pull/50428) and the regenerated policy compares `bundle_version`:

```sql
SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.valvesoftware.steam' AND version_compare(bundle_version, '6.0') < 0);
```

Steam.app ships without a `CFBundleShortVersionString`, so the previous query compared an empty string and the policy could never pass on a host with Steam installed ([fleetdm/fleet#50408](https://github.com/fleetdm/fleet/issues/50408)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)