### PR TITLE
Scope FMA patch policies to hosts with the app installed

### DIFF
--- a/labels/fma-installed-macos.yml
+++ b/labels/fma-installed-macos.yml
@@ -1,0 +1,188 @@
+- name: 1Password installed
+  description: macOS hosts with 1Password installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';
+  label_membership_type: dynamic
+- name: Adobe Acrobat Reader installed
+  description: macOS hosts with Adobe Acrobat Reader installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader';
+  label_membership_type: dynamic
+- name: balenaEtcher installed
+  description: macOS hosts with balenaEtcher installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'io.balena.etcher';
+  label_membership_type: dynamic
+- name: Canva installed
+  description: macOS hosts with Canva installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.canva.CanvaDesktop';
+  label_membership_type: dynamic
+- name: ChatGPT installed
+  description: macOS hosts with ChatGPT installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';
+  label_membership_type: dynamic
+- name: Claude installed
+  description: macOS hosts with Claude installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';
+  label_membership_type: dynamic
+- name: CleanShot X installed
+  description: macOS hosts with CleanShot X installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.getcleanshot.app';
+  label_membership_type: dynamic
+- name: Cursor installed
+  description: macOS hosts with Cursor installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';
+  label_membership_type: dynamic
+- name: Discord installed
+  description: macOS hosts with Discord installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord';
+  label_membership_type: dynamic
+- name: DisplayLink installed
+  description: macOS hosts with DisplayLink installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.displaylink.DisplayLinkUserAgent';
+  label_membership_type: dynamic
+- name: Docker Desktop installed
+  description: macOS hosts with Docker Desktop installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';
+  label_membership_type: dynamic
+- name: DYMO Connect installed
+  description: macOS hosts with DYMO Connect installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.dymo.DYMO-WebApi-Mac-Host';
+  label_membership_type: dynamic
+- name: Elgato Control Center installed
+  description: macOS hosts with Elgato Control Center installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.corsair.ControlCenter';
+  label_membership_type: dynamic
+- name: Elgato Stream Deck installed
+  description: macOS hosts with Elgato Stream Deck installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.elgato.StreamDeck';
+  label_membership_type: dynamic
+- name: Fleet Desktop installed
+  description: macOS hosts with the standalone Fleet Desktop app installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.fleetdm.fleet-desktop';
+  label_membership_type: dynamic
+- name: Ghostty installed
+  description: macOS hosts with Ghostty installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.mitchellh.ghostty';
+  label_membership_type: dynamic
+- name: GitHub Desktop installed
+  description: macOS hosts with GitHub Desktop installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient';
+  label_membership_type: dynamic
+- name: Google Chrome installed
+  description: macOS hosts with Google Chrome installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';
+  label_membership_type: dynamic
+- name: Google Drive installed
+  description: macOS hosts with Google Drive installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs';
+  label_membership_type: dynamic
+- name: GPG Suite installed
+  description: macOS hosts with GPG Suite installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'org.gpgtools.updater';
+  label_membership_type: dynamic
+- name: HandBrake installed
+  description: macOS hosts with HandBrake installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'fr.handbrake.HandBrake';
+  label_membership_type: dynamic
+- name: iMazing Converter installed
+  description: macOS hosts with iMazing Converter installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.DigiDNA.iMazingHEICConverterMac';
+  label_membership_type: dynamic
+- name: iMazing Profile Editor installed
+  description: macOS hosts with iMazing Profile Editor installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.DigiDNA.iMazingProfileEditorMac';
+  label_membership_type: dynamic
+- name: iTerm2 installed
+  description: macOS hosts with iTerm2 installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.googlecode.iterm2';
+  label_membership_type: dynamic
+- name: Logi Options+ installed
+  description: macOS hosts with Logi Options+ installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.logi.optionsplus';
+  label_membership_type: dynamic
+- name: MeetingBar installed
+  description: macOS hosts with MeetingBar installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'leits.MeetingBar';
+  label_membership_type: dynamic
+- name: Microsoft Teams installed
+  description: macOS hosts with Microsoft Teams installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2';
+  label_membership_type: dynamic
+- name: Visual Studio Code installed
+  description: macOS hosts with Visual Studio Code installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';
+  label_membership_type: dynamic
+- name: Notion installed
+  description: macOS hosts with Notion installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'notion.id';
+  label_membership_type: dynamic
+- name: Ollama installed
+  description: macOS hosts with Ollama installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';
+  label_membership_type: dynamic
+- name: Postman installed
+  description: macOS hosts with Postman installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';
+  label_membership_type: dynamic
+- name: Raycast installed
+  description: macOS hosts with Raycast installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';
+  label_membership_type: dynamic
+- name: Signal installed
+  description: macOS hosts with Signal installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';
+  label_membership_type: dynamic
+- name: Slack installed
+  description: macOS hosts with Slack installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap';
+  label_membership_type: dynamic
+- name: Spotify installed
+  description: macOS hosts with Spotify installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client';
+  label_membership_type: dynamic
+- name: Steam installed
+  description: macOS hosts with Steam installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.valvesoftware.steam';
+  label_membership_type: dynamic
+- name: Sublime Text installed
+  description: macOS hosts with Sublime Text installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.sublimetext.4';
+  label_membership_type: dynamic
+- name: Suspicious Package installed
+  description: macOS hosts with Suspicious Package installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.SuspiciousPackageApp';
+  label_membership_type: dynamic
+- name: Tailscale installed
+  description: macOS hosts with Tailscale installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'io.tailscale.ipn.macsys';
+  label_membership_type: dynamic
+- name: TextExpander installed
+  description: macOS hosts with TextExpander installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.smileonmymac.textexpander';
+  label_membership_type: dynamic
+- name: The Unarchiver installed
+  description: macOS hosts with The Unarchiver installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'cx.c3.theunarchiver';
+  label_membership_type: dynamic
+- name: Transmit installed
+  description: macOS hosts with Transmit installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.panic.Transmit';
+  label_membership_type: dynamic
+- name: UTM installed
+  description: macOS hosts with UTM installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.utmapp.UTM';
+  label_membership_type: dynamic
+- name: VLC installed
+  description: macOS hosts with VLC installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'org.videolan.vlc';
+  label_membership_type: dynamic
+- name: WhatsApp installed
+  description: macOS hosts with WhatsApp installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';
+  label_membership_type: dynamic
+- name: Yubico Authenticator installed
+  description: macOS hosts with Yubico Authenticator installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.yubico.yubioath';
+  label_membership_type: dynamic
+- name: Zoom installed
+  description: macOS hosts with Zoom installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.xos';
+  label_membership_type: dynamic

--- a/platforms/macos/policies/macos-fma-patch.policies.yml
+++ b/platforms/macos/policies/macos-fma-patch.policies.yml
@@ -2,187 +2,281 @@
   type: patch
   fleet_maintained_app_slug: 1password/darwin
   install_software: true
+  labels_include_any:
+  - 1Password installed
 - name: Adobe Acrobat Reader up to date
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-reader/darwin
   install_software: true
+  labels_include_any:
+  - Adobe Acrobat Reader installed
 - name: balenaEtcher up to date
   type: patch
   fleet_maintained_app_slug: balenaetcher/darwin
   install_software: true
+  labels_include_any:
+  - balenaEtcher installed
 - name: Canva up to date
   type: patch
   fleet_maintained_app_slug: canva/darwin
   install_software: true
+  labels_include_any:
+  - Canva installed
 - name: ChatGPT up to date
   type: patch
   fleet_maintained_app_slug: chatgpt/darwin
   install_software: true
+  labels_include_any:
+  - ChatGPT installed
 - name: Claude up to date
   type: patch
   fleet_maintained_app_slug: claude/darwin
   install_software: true
+  labels_include_any:
+  - Claude installed
 - name: CleanShot X up to date
   type: patch
   fleet_maintained_app_slug: cleanshot/darwin
   install_software: true
+  labels_include_any:
+  - CleanShot X installed
 - name: Cursor up to date
   type: patch
   fleet_maintained_app_slug: cursor/darwin
   install_software: true
+  labels_include_any:
+  - Cursor installed
 - name: Discord up to date
   type: patch
   fleet_maintained_app_slug: discord/darwin
   install_software: true
+  labels_include_any:
+  - Discord installed
 - name: DisplayLink up to date
   type: patch
   fleet_maintained_app_slug: displaylink/darwin
   install_software: true
+  labels_include_any:
+  - DisplayLink installed
 - name: Docker Desktop up to date
   type: patch
   fleet_maintained_app_slug: docker-desktop/darwin
   install_software: true
+  labels_include_any:
+  - Docker Desktop installed
 - name: DYMO Connect up to date
   type: patch
   fleet_maintained_app_slug: dymo-connect/darwin
   install_software: true
+  labels_include_any:
+  - DYMO Connect installed
 - name: Elgato Control Center up to date
   type: patch
   fleet_maintained_app_slug: elgato-control-center/darwin
   install_software: true
+  labels_include_any:
+  - Elgato Control Center installed
 - name: Elgato Stream Deck up to date
   type: patch
   fleet_maintained_app_slug: elgato-stream-deck/darwin
   install_software: true
+  labels_include_any:
+  - Elgato Stream Deck installed
 - name: Fleet Desktop up to date
   type: patch
   fleet_maintained_app_slug: fleet-desktop/darwin
   install_software: true
+  labels_include_any:
+  - Fleet Desktop installed
 - name: Ghostty up to date
   type: patch
   fleet_maintained_app_slug: ghostty/darwin
   install_software: true
+  labels_include_any:
+  - Ghostty installed
 - name: GitHub Desktop up to date
   type: patch
   fleet_maintained_app_slug: github/darwin
   install_software: true
+  labels_include_any:
+  - GitHub Desktop installed
 - name: Google Chrome up to date
   type: patch
   fleet_maintained_app_slug: google-chrome/darwin
   install_software: true
+  labels_include_any:
+  - Google Chrome installed
 - name: Google Drive up to date
   type: patch
   fleet_maintained_app_slug: google-drive/darwin
   install_software: true
+  labels_include_any:
+  - Google Drive installed
 - name: GPG Suite up to date
   type: patch
   fleet_maintained_app_slug: gpg-suite/darwin
   install_software: true
+  labels_include_any:
+  - GPG Suite installed
 - name: HandBrake up to date
   type: patch
   fleet_maintained_app_slug: handbrake-app/darwin
   install_software: true
+  labels_include_any:
+  - HandBrake installed
 - name: iMazing Converter up to date
   type: patch
   fleet_maintained_app_slug: imazing-converter/darwin
   install_software: true
+  labels_include_any:
+  - iMazing Converter installed
 - name: iMazing Profile Editor up to date
   type: patch
   fleet_maintained_app_slug: imazing-profile-editor/darwin
   install_software: true
+  labels_include_any:
+  - iMazing Profile Editor installed
 - name: iTerm2 up to date
   type: patch
   fleet_maintained_app_slug: iterm2/darwin
   install_software: true
+  labels_include_any:
+  - iTerm2 installed
 - name: Logi Options+ up to date
   type: patch
   fleet_maintained_app_slug: logi-options+/darwin
   install_software: true
+  labels_include_any:
+  - Logi Options+ installed
 - name: MeetingBar up to date
   type: patch
   fleet_maintained_app_slug: meetingbar/darwin
   install_software: true
+  labels_include_any:
+  - MeetingBar installed
 - name: Microsoft Teams up to date
   type: patch
   fleet_maintained_app_slug: microsoft-teams/darwin
   install_software: true
+  labels_include_any:
+  - Microsoft Teams installed
 - name: Visual Studio Code up to date
   type: patch
   fleet_maintained_app_slug: visual-studio-code/darwin
   install_software: true
+  labels_include_any:
+  - Visual Studio Code installed
 - name: Notion up to date
   type: patch
   fleet_maintained_app_slug: notion/darwin
   install_software: true
+  labels_include_any:
+  - Notion installed
 - name: Ollama up to date
   type: patch
   fleet_maintained_app_slug: ollama/darwin
   install_software: true
+  labels_include_any:
+  - Ollama installed
 - name: Postman up to date
   type: patch
   fleet_maintained_app_slug: postman/darwin
   install_software: true
+  labels_include_any:
+  - Postman installed
 - name: Raycast up to date
   type: patch
   fleet_maintained_app_slug: raycast/darwin
   install_software: true
+  labels_include_any:
+  - Raycast installed
 - name: Signal up to date
   type: patch
   fleet_maintained_app_slug: signal/darwin
   install_software: true
+  labels_include_any:
+  - Signal installed
 - name: Slack up to date
   type: patch
   fleet_maintained_app_slug: slack/darwin
   install_software: true
+  labels_include_any:
+  - Slack installed
 - name: Spotify up to date
   type: patch
   fleet_maintained_app_slug: spotify/darwin
   install_software: true
+  labels_include_any:
+  - Spotify installed
 - name: Steam up to date
   type: patch
   fleet_maintained_app_slug: steam/darwin
   install_software: true
+  labels_include_any:
+  - Steam installed
 - name: Sublime Text up to date
   type: patch
   fleet_maintained_app_slug: sublime-text/darwin
   install_software: true
+  labels_include_any:
+  - Sublime Text installed
 - name: Suspicious Package up to date
   type: patch
   fleet_maintained_app_slug: suspicious-package/darwin
   install_software: true
+  labels_include_any:
+  - Suspicious Package installed
 - name: Tailscale up to date
   type: patch
   fleet_maintained_app_slug: tailscale-app/darwin
   install_software: true
+  labels_include_any:
+  - Tailscale installed
 - name: TextExpander up to date
   type: patch
   fleet_maintained_app_slug: textexpander/darwin
   install_software: true
+  labels_include_any:
+  - TextExpander installed
 - name: The Unarchiver up to date
   type: patch
   fleet_maintained_app_slug: the-unarchiver/darwin
   install_software: true
+  labels_include_any:
+  - The Unarchiver installed
 - name: Transmit up to date
   type: patch
   fleet_maintained_app_slug: transmit/darwin
   install_software: true
+  labels_include_any:
+  - Transmit installed
 - name: UTM up to date
   type: patch
   fleet_maintained_app_slug: utm/darwin
   install_software: true
+  labels_include_any:
+  - UTM installed
 - name: VLC up to date
   type: patch
   fleet_maintained_app_slug: vlc/darwin
   install_software: true
+  labels_include_any:
+  - VLC installed
 - name: WhatsApp up to date
   type: patch
   fleet_maintained_app_slug: whatsapp/darwin
   install_software: true
+  labels_include_any:
+  - WhatsApp installed
 - name: Yubico Authenticator up to date
   type: patch
   fleet_maintained_app_slug: yubico-authenticator/darwin
   install_software: true
+  labels_include_any:
+  - Yubico Authenticator installed
 - name: Zoom up to date
   type: patch
   fleet_maintained_app_slug: zoom/darwin
   install_software: true
+  labels_include_any:
+  - Zoom installed


### PR DESCRIPTION
## Summary
- Adds `labels/fma-installed-macos.yml` with one dynamic label per Fleet Maintained App, each matching the `apps.bundle_identifier` Fleet itself uses to detect that app (sourced from Fleet's maintained-apps manifests).
- Adds `labels_include_any` to each of the 47 patch policies in `platforms/macos/policies/macos-fma-patch.policies.yml`, scoping each one to its corresponding "installed" label.

Previously every patch policy ran against all workstations, so hosts without a given app still failed its "up to date" policy. Now each policy only evaluates on hosts where that app is actually present.

## Test plan
- [x] `fleetctl gitops` dry-run / apply succeeds
- [ ] Confirm new labels populate in Fleet and match expected hosts
- [ ] Confirm patch policies only show as applicable on hosts with the corresponding app installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)