### PR TITLE
Add "Asset Tag" custom host vital

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -13,6 +13,8 @@ agent_options:
       logger_tls_period: 10
       pack_delimiter: /
   overrides:
+custom_host_vitals:
+  - name: Asset Tag
 labels:
   - paths: ./labels/*.yml
 org_settings:


### PR DESCRIPTION
## Summary
- Adds a global `custom_host_vitals` entry named "Asset Tag" to `default.yml`, so it becomes available as `$FLEET_HOST_VITAL_<id>` for use in scripts and configuration profiles.

## Test plan
- [ ] `fleetctl gitops` apply succeeds
- [ ] "Asset Tag" appears under Controls > Variables > Custom host vitals in the Fleet UI
- [ ] Set a per-host value and confirm it resolves correctly when referenced in a script/profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)