### PR TITLE
Add "Asset tag test" host vitals label

### DIFF
--- a/labels/asset-tag-test.yml
+++ b/labels/asset-tag-test.yml
@@ -1,0 +1,7 @@
+- name: "Asset tag test"
+  description: Hosts whose Asset Tag custom host vital is set to "Test"
+  label_membership_type: host_vitals
+  criteria:
+    vital: custom_host_vital
+    custom_host_vital_id: 1
+    value: Test


### PR DESCRIPTION
## Summary
- Adds a `host_vitals`-type label, "Asset tag test", matching hosts where the custom "Asset Tag" host vital (id `1`, added in #210) equals `Test`.
- Custom host vitals in label criteria use `vital: custom_host_vital` plus `custom_host_vital_id` to disambiguate which vital, since the vital's name alone isn't enough to identify it (this isn't documented yet — confirmed from Fleet's `server/fleet/labels.go` and `pkg/spec/gitops.go`).

## Test plan
- [ ] `fleetctl gitops` apply succeeds
- [ ] "Asset tag test" label appears in Fleet UI with type "Host vitals"
- [ ] Setting a host's Asset Tag vital value to "Test" adds it to the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)