### PR TITLE
Set Apple OS update deadline to 5 days, bump macOS to 26.6.1

### DIFF
--- a/fleets/mobile-devices.yml
+++ b/fleets/mobile-devices.yml
@@ -15,10 +15,10 @@ agent_options:
 controls:
   enable_disk_encryption: true
   ios_updates:
-    deadline: "2026-07-31"
+    deadline: "2026-08-16"
     minimum_version: "26.6"
   ipados_updates:
-    deadline: "2026-07-31"
+    deadline: "2026-08-16"
     minimum_version: "26.6"
   apple_settings:
     configuration_profiles:

--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -31,8 +31,8 @@ controls:
   enable_disk_encryption: true
   enable_recovery_lock_password: true
   macos_updates:
-    deadline: '2026-07-31'
-    minimum_version: '26.6'
+    deadline: '2026-08-16'
+    minimum_version: '26.6.1'
   apple_settings:
     configuration_profiles:
     - paths: ../platforms/macos/declaration-profiles/all-macos/*.json


### PR DESCRIPTION
## Summary
- Refreshes `macos_updates`, `ios_updates`, and `ipados_updates` deadlines in `fleets/workstations.yml` and `fleets/mobile-devices.yml` from `2026-07-31` (already past) to `2026-08-16` — 5 days out.
- Bumps `macos_updates.minimum_version` to `26.6.1`, which Apple released GA on 2026-08-06 as a security fix for a Screen Sharing auth-bypass CVE (no beta phase).
- Leaves `ios_updates`/`ipados_updates.minimum_version` at `26.6` — iOS/iPadOS 26.6.1 is still in RC/beta as of this PR, not yet public.

## Test plan
- [ ] `fleetctl gitops` dry-run / CI validation passes
- [ ] Confirm Workstations and Mobile Devices hosts show the updated deadline and minimum OS version in Fleet after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)