### PR TITLE
Temporarily disable patch policies

### DIFF
--- a/fleets/workstations.yml
+++ b/fleets/workstations.yml
@@ -1,7 +1,8 @@
 name: Workstations
 policies:
 - path: ../platforms/macos/policies/macos-device-health.policies.yml
-- path: ../platforms/macos/policies/macos-fma-patch.policies.yml
+# TEMPORARILY DISABLED: patch policies (re-enable by uncommenting)
+#- path: ../platforms/macos/policies/macos-fma-patch.policies.yml
 - path: ../platforms/macos/policies/macos-fma-install.policies.yml
 - path: ../platforms/all/policies/npm-user-npmrc-min-release-age.policies.yml
 reports:


### PR DESCRIPTION
Comments out the `macos-fma-patch.policies.yml` path in `fleets/workstations.yml` — the only fleet that wires it, so this covers every patch policy in the repo.

GitOps apply is declarative, so this **removes** all Fleet-maintained app patch policies from Fleet (along with their per-host pass/fail history) until the line is uncommented.

If the intent was only to stop auto-remediation while keeping the policies visible in Fleet, the alternative is flipping `install_software: true` → `false` across `platforms/macos/policies/macos-fma-patch.policies.yml` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)